### PR TITLE
Check for calloc() failure to prevent segmentation fault in onion_new()

### DIFF
--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -194,6 +194,9 @@ onion *onion_new(int flags){
 	}
 	
 	onion *o=calloc(1,sizeof(onion));
+	if (!o){
+		return NULL;
+	}
 	o->flags=(flags&0x0FF)|O_SSL_AVAILABLE;
 	o->timeout=5000; // 5 seconds of timeout, default.
 	o->poller=onion_poller_new(15);


### PR DESCRIPTION
Previously in the function onion_new(), the onion\* object would be allocated via calloc() then immediately put to use (e.g. o->flags=...). If calloc() fails (e.g. when out of memory), this will result in a segmentation fault. This commit checks if the allocation succeeded and, if it did not, returns NULL.
