### PR TITLE
Do not mask websocket frames on send.

### DIFF
--- a/src/onion/websocket.c
+++ b/src/onion/websocket.c
@@ -157,13 +157,12 @@ void onion_websocket_free(onion_websocket *ws){
 int onion_websocket_write(onion_websocket* ws, const char* buffer, size_t _len)
 {
 	int len=_len; // I need it singed here
-	char mask[4];
 	//ONION_DEBUG("Write %d bytes",len);
 	{
 		char header[16];
 		int hlen=2;
 		header[0]=0x80|(ws->opcode&0x0F); // Also final in fragment.
-		header[1]=0x80; // With mask
+		header[1]=0x00; // Do not mask on send
 		if (len<126)
 			header[1]|=len;
 		else if (len<0x0FFFF){
@@ -182,12 +181,6 @@ int onion_websocket_write(onion_websocket* ws, const char* buffer, size_t _len)
 			}
 			hlen+=8;
 		}
-		onion_random_generate(mask,4);
-		
-		header[hlen++]=mask[0];
-		header[hlen++]=mask[1];
-		header[hlen++]=mask[2];
-		header[hlen++]=mask[3];
 		
 		/*
 		int i;
@@ -205,13 +198,13 @@ int onion_websocket_write(onion_websocket* ws, const char* buffer, size_t _len)
 	for(i=0;i<len-1024;i+=1024){
 		for (j=0;j<sizeof(tout);j++){
 			//ONION_DEBUG("At %d, %02X ^ %02X = %02X", (i+j)&1023, buffer[i+j]&0x0FF, mask[j&3]&0x0FF, (buffer[i]^mask[j&3])&0x0FF);
-			tout[j]=buffer[i+j]^mask[j&3];
+			tout[j]=buffer[i+j];
 		}
 		ret+=ws->req->connection.listen_point->write(ws->req, tout, sizeof(tout));
 	}
 	for(;i<len;i++){
 		//ONION_DEBUG("At %d, %02X ^ %02X = %02X", i&1023, buffer[i]&0x0FF, mask[i&3]&0x0FF, (buffer[i]^mask[i&3])&0x0FF);
-		tout[i&1023]=buffer[i]^mask[i&3];
+		tout[i&1023]=buffer[i];
 	}
 	
 	return ret+ws->req->connection.listen_point->write(ws->req, tout, len&1023);


### PR DESCRIPTION
This fixes websockets for Chrome (fixes Issue #22). Without this fix a connection attempt to a libonion websocket server is immediately terminated with the following error message:

WebSocket connection to '[...]' failed: A server must not mask any frames that it sends to the client.
