### PR TITLE
Making sure to utilize return value of read() in random number generatio...

### DIFF
--- a/src/onion/random-default.c
+++ b/src/onion/random-default.c
@@ -63,9 +63,15 @@ void onion_random_init() {
 		}
 		else{
 			unsigned int sr;
-			read(fd, &sr, sizeof(sr));
-			close(fd);
-			srand(sr);
+			ssize_t n;
+			n = read(fd, &sr, sizeof(sr));
+			if (n != sizeof(sr)) {
+				ONION_ERROR("Error reading seed value from /dev/random after file descriptor opened");
+				exit(1);
+			} else {
+				close(fd);
+				srand(sr);
+			}
 		}
 	}
 	onion_random_refcount++;


### PR DESCRIPTION
Just to fix:

**error: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Werror=unused-result]**
    **read(fd, &sr, sizeof(sr));**

This of course may not be how you want to handle this. Anyway, this was the only error I encountered during compilation with GCC version: gcc (Ubuntu/Linaro 4.8.1-10ubuntu9) 4.8.1), Linux 3.4, arm7l.

Thanks!
