### PR TITLE
C++ fixes for old gcc (SLE_11, RHEL-6)

### DIFF
--- a/tests/08-cpp/02-dict.cpp
+++ b/tests/08-cpp/02-dict.cpp
@@ -187,7 +187,12 @@ void t05_context(){
 void t06_tomap(){
 	INIT_LOCAL();
 	
+#if __cplusplus > 199711L
 	std::map<std::string, std::string> orig{{"Hello","World"}};
+#else
+	std::map<std::string, std::string> orig;
+	orig.insert(std::pair< std::string, std::string>("Hello","World"));
+#endif
 	Onion::Dict d(orig);
 	
 	std::map<std::string, std::string> dup=d;


### PR DESCRIPTION
I appreciate that onion seems to be very portable. Here is a minor fix to let it build on current suse and red hat enterprise.
