### PR TITLE
build: fix version number if we don't have git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@ SET(ONION_POLLER default CACHE string "Default poller to use: default | epoll | 
 ########
 
 execute_process(
-	COMMAND sh -c "git describe | sed -e 's/v//g' -e 's/-/./g' | tr -d '\n'"
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/git-version-gen" "${CMAKE_CURRENT_SOURCE_DIR}"
 	OUTPUT_VARIABLE ONION_VERSION)
 
 message(STATUS "Onion version is ${ONION_VERSION}")

--- a/git-version-gen
+++ b/git-version-gen
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# usage: git-version-gen [srcdir]
+
+DEF_VER="v0.7.GIT"
+
+LF='
+'
+
+srcdir="."
+if test "x${1}" != "x"
+then
+	srcdir="${1}"
+fi
+
+# First see if there is a version file (included in release tarballs),
+# then try git-describe, then default.
+cd "${srcdir}" || exit 1
+if test -f version
+then
+	VN="`cat version`" || VN="${DEF_VER}"
+elif test -d .git -o -f .git &&
+	VN="`git describe --match "v[0-9]*" --abbrev=5 HEAD 2>/dev/null`" &&
+	case "${VN}" in
+	*"${LF}"*) (exit 1) ;;
+	v[0-9]*)
+		git update-index -q --refresh
+		test -z "`git diff-index --name-only HEAD --`" ||
+		VN="${VN}-dirty" ;;
+	esac
+then
+	# convert "v0.4.0-32-gf350f" to "v0.4.0.git32.f350f"
+	VN="`echo "${VN}" | sed -e 's/-\([0-9]*\)-g/.git\1./g' -e 's/-/./g'`";
+else
+	VN="${DEF_VER}"
+fi
+
+VN="`expr "${VN}" : v*'\(.*\)'`"
+
+echo "${VN}" | tr -d "$LF" 
+


### PR DESCRIPTION
Please read the commit message for more info.

BTW I see that now you are using the package version also for the library version.  Maybe you want to reconsider this according to the libtool manual 
http://www.gnu.org/software/libtool/manual/libtool.html#Versioning
Specially point 7.3:
"Never try to set the interface numbers so that they correspond to the release number of your package. This is an abuse that only fosters misunderstanding of the purpose of library versions."
