### PR TITLE
build: fix renaming of example binaries

### DIFF
--- a/examples/cairo/CMakeLists.txt
+++ b/examples/cairo/CMakeLists.txt
@@ -3,4 +3,4 @@ include_directories (${PROJECT_SOURCE_DIR}/src/)
 add_executable(cairo_example cairo.c)
 target_link_libraries(cairo_example onion onion_extras cairo m)
 
-install(TARGETS cairo_example DESTINATION ${CMAKE_INSTALL_BINDIR}/onion-cairo-example)
+install(TARGETS cairo_example DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME onion-cairo-example)

--- a/examples/fileserver/CMakeLists.txt
+++ b/examples/fileserver/CMakeLists.txt
@@ -3,4 +3,4 @@ include_directories (${PROJECT_SOURCE_DIR}/src/)
 add_executable(fileserver fileserver.c)
 target_link_libraries(fileserver onion_handlers onion_static)
 
-install(TARGETS fileserver DESTINATION ${CMAKE_INSTALL_BINDIR}/onion-fileserver)
+install(TARGETS fileserver DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME onion-fileserver)

--- a/examples/interactive/CMakeLists.txt
+++ b/examples/interactive/CMakeLists.txt
@@ -4,5 +4,5 @@ add_executable(interactive interactive.c)
 
 target_link_libraries(interactive onion_static)
 
-install(TARGETS interactive DESTINATION ${CMAKE_INSTALL_BINDIR}/onion-interactive)
+install(TARGETS interactive DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME onion-interactive)
 

--- a/examples/ofileserver/CMakeLists.txt
+++ b/examples/ofileserver/CMakeLists.txt
@@ -46,5 +46,5 @@ if (${Z_LIB})
    target_link_libraries(ofileserver ${Z_LIB})
 endif(${Z_LIB})
 
-install(TARGETS ofileserver DESTINATION ${CMAKE_INSTALL_BINDIR}/onion-ofileserver)
+install(TARGETS ofileserver DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME onion-ofileserver)
 


### PR DESCRIPTION
We don't want to create subdirs in /usr/bin/ but just prefixing
these example binaries.
