### PR TITLE
Fixed memory leak in example

### DIFF
--- a/examples/post/post.c
+++ b/examples/post/post.c
@@ -32,6 +32,7 @@ onion_connection_status post_data(void *_, onion_request *req, onion_response *r
 	}
 	const char *user_data=onion_request_get_post(req,"text");
 	onion_response_printf(res, "The user wrote: %s", user_data);
+	free(user_data);
 	return OCS_PROCESSED;
 }
 


### PR DESCRIPTION
onion_request_get_post returns a string that needs to be freed or else there is a memory leak.
