### PR TITLE
Websocket callbacks are called with -1 length on end-of-input

### DIFF
--- a/examples/websockets/websockets.c
+++ b/examples/websockets/websockets.c
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <unistd.h>
 
-onion_connection_status websocket_example_cont(void *data, onion_websocket *ws, size_t data_ready_len);
+onion_connection_status websocket_example_cont(void *data, onion_websocket *ws, ssize_t data_ready_len);
 
 onion_connection_status websocket_example(void *data, onion_request *req, onion_response *res){
 	onion_websocket *ws=onion_websocket_new(req, res);
@@ -45,7 +45,7 @@ onion_connection_status websocket_example(void *data, onion_request *req, onion_
 	return OCS_WEBSOCKET;
 }
 
-onion_connection_status websocket_example_cont(void *data, onion_websocket *ws, size_t data_ready_len){
+onion_connection_status websocket_example_cont(void *data, onion_websocket *ws, ssize_t data_ready_len){
 	char tmp[256];
 	if (data_ready_len>sizeof(tmp))
 		data_ready_len=sizeof(tmp)-1;

--- a/src/onion/types.h
+++ b/src/onion/types.h
@@ -278,18 +278,20 @@ typedef void (*onion_handler_private_data_free)(void *privdata);
  * 
  * The callbacks are the functions to be called when new data is available on websockets.
  * 
- * They are not mandatory, but when used they can be changed from the callback itself, using
- * onion_websocket_set_callback. If data is left for read after a callback call, next callback is 
- * called with that data. If same callback stays, and no data has been consumed, it will not 
- * be called until new data is available. 
+ * They are not mandatory, but when used they can be changed from the
+ * callback itself, using onion_websocket_set_callback. If data is
+ * left for read after a callback call, next callback is called with
+ * that data. If same callback stays, and no data has been consumed,
+ * it will not be called until new data is available.  End of input,
+ * or websocket removal is notified with a negative data_ready_length.
  * 
- * The privte data is that of the original request handler.
+ * The private data is that of the original request handler.
  * 
  * This chaining of callbacks allows easy creation of state machines. 
  * 
  * @returns OCS_INTERNAL_ERROR | OCS_CLOSE_CONNECTION | OCS_NEED_MORE_DATA. Other returns result in OCS_INTERNAL_ERROR.
  */
-typedef onion_connection_status (*onion_websocket_callback_t)(void *privdata, onion_websocket *ws, size_t data_ready_length);
+typedef onion_connection_status (*onion_websocket_callback_t)(void *privdata, onion_websocket *ws, ssize_t data_ready_length);
 
 
 #ifdef __cplusplus

--- a/src/onion/websocket.h
+++ b/src/onion/websocket.h
@@ -36,6 +36,7 @@ extern "C"{
 
 /// Get the current websocket handler, or create it. If not a websocket request, returns NULL
 onion_websocket *onion_websocket_new(onion_request *req, onion_response *res);
+/// When freed, the callback is invoked with a negative data length.
 void onion_websocket_free(onion_websocket *ws);
 void onion_websocket_close(onion_websocket *ws);
 

--- a/tests/01-internal/14-websockets.c
+++ b/tests/01-internal/14-websockets.c
@@ -28,7 +28,7 @@ struct ws_status_t{
 };
 struct ws_status_t ws_status;
 
-onion_connection_status ws_callback(void *privadata, onion_websocket *ws, size_t nbytes_ready){
+onion_connection_status ws_callback(void *privadata, onion_websocket *ws, ssize_t nbytes_ready){
 	return OCS_NEED_MORE_DATA;
 }
 


### PR DESCRIPTION
The length argument of websocket callbacks can be negative on end-of-input