### PR TITLE
poller: Fix syntax error

### DIFF
--- a/src/onion/poller_libevent.c
+++ b/src/onion/poller_libevent.c
@@ -52,7 +52,7 @@ typedef struct onion_poller_slot_t onion_poller_slot;
 /// Create a new slot for the poller
 onion_poller_slot *onion_poller_slot_new(int fd, int (*f)(void*), void *data){
 	onion_poller_slot *ret=onion_low_calloc(1, sizeof(onion_poller_slot));
-	ret->fd=fd;<
+	ret->fd=fd;
 	ret->f=f;
 	ret->data=data;
 	ret->type=EV_READ | EV_WRITE | EV_PERSIST;


### PR DESCRIPTION
In commit 866793271147a7852f098e446c948f19e5ca27ec, a syntax error was
(probably inadvertently) added.  This fixes that error.