### PR TITLE
Fix Url memory leak.

### DIFF
--- a/src/bindings/cpp/url.cpp
+++ b/src/bindings/cpp/url.cpp
@@ -46,8 +46,9 @@ Onion::Url::Url(Onion& o)
 }
 
 Onion::Url::Url(Url &&o)
-	: ptr { std::move(o.ptr) }
+	: ptr { o.ptr.get(), &onion_url_free }
 {
+  o.ptr.get_deleter() = [](onion_url*) -> void {};
 }
 
 Onion::Url::~Url()


### PR DESCRIPTION
Hi David,

When I changed the Url class to use automatic memory management, I missed the fact that the original Url object is still usable after a move. This pull request should fix that issue.

Thanks,
Zack