### PR TITLE
Fix null pointer dereference.

### DIFF
--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -822,6 +822,7 @@ int onion_set_certificate_va(onion *onion, onion_ssl_certificate_type type, cons
 			  ? onion_low_strdup(first_listen_point->hostname) : NULL;
 			onion_listen_point_free(first_listen_point);
 			onion_listen_point *https=onion_https_new();
+			https->server = onion;
 			if (NULL==https){
 				ONION_ERROR("Could not promote from HTTP to HTTPS. Certificate not set.");
 			}


### PR DESCRIPTION
When looking at Issue #20, I discovered that the code that sets the
https certificates doesn't correctly initialize the listen point. This
causes a segfault when systemd support is compiled in. This initializes
the listen point correctly.