### PR TITLE
Switched to move semantics to make things more natural.

### DIFF
--- a/examples/multiport-cpp/multiport.cpp
+++ b/examples/multiport-cpp/multiport.cpp
@@ -16,7 +16,7 @@ int main(int argc, char*argv[]){
 #ifdef HAVE_GNUTLS
 	Onion::HttpsListenPoint https;
 	https.setCertificate(O_SSL_CERTIFICATE_KEY, "cert.pem", "cert.key");
-	o.addListenPoint("localhost", "4443", https);
+	o.addListenPoint("localhost", "4443", std::move(https));
 #else
 	ONION_WARNING("HTTPS support is not enabled. Recompile with gnutls");
 #endif

--- a/src/bindings/cpp/http.hpp
+++ b/src/bindings/cpp/http.hpp
@@ -29,8 +29,6 @@
 namespace Onion {
 	/**
 	 * @short A HTTP listen point for an Onion::Onion object.
-	 * @see Onion::ListenPoint for information about
-	 * allocation/deallocation of this object.
 	 *
 	 * This is a short example of how to use this object.
 	 * @code

--- a/src/bindings/cpp/https.hpp
+++ b/src/bindings/cpp/https.hpp
@@ -30,15 +30,13 @@
 namespace Onion {
 	/**
 	 * @short A HTTPS listen point for an Onion::Onion object.
-	 * @see Onion::ListenPoint for information about
-	 * allocation/deallocation of this object.
 	 *
 	 * This is a short example of how to use this object.
 	 * @code
 	 * Onion::Onion o;
 	 * Onion::HttpsListenPoint https {};
 	 * https.setCertificate(O_SSL_CERTIFICATE_KEY, "cert.pem", "cert.key");
-	 * o.addListenPoint("localhost", "443", https);
+	 * o.addListenPoint("localhost", "443", std::move(https));
 	 * o.listen();
 	 * @endcode
 	 */

--- a/src/bindings/cpp/listen_point.hpp
+++ b/src/bindings/cpp/listen_point.hpp
@@ -30,10 +30,7 @@ namespace Onion {
 	/**
 	 * @short Creates a listen point for an Onion::Onion object.
 	 * Not meant to be used directly, as a default listen point doesn't
-	 * do very much. Also, this class doesn't directly free associated
-	 * resources. However, when an Onion::Onion object is freed, it will
-	 * free associated resources when it is deconstructed. So, make sure
-	 * you add a ListenPoint to an Onion::Onion object.
+	 * do very much.
 	 */
 	class ListenPoint {
 	protected:
@@ -41,12 +38,22 @@ namespace Onion {
 		internal_pointer ptr;
 	public:
 		ListenPoint() 
-			: ptr(onion_listen_point_new(), [](onion_listen_point*) { return; })
+			: ptr(onion_listen_point_new(), onion_listen_point_free)
 		{}
 
 		ListenPoint(onion_listen_point* lp)
 			: ptr(lp, [](onion_listen_point*) { return; })
 		{}
+
+		ListenPoint(ListenPoint&& other) : ptr { std::move(other.ptr) }
+		{}
+
+		/**
+		 * @short Release ownership of the underlying pointer.
+		 */
+		void release() {
+			ptr.reset(nullptr);
+		}
 
 		/**
 		 * @short Get the underlying C object.

--- a/src/bindings/cpp/onion.hpp
+++ b/src/bindings/cpp/onion.hpp
@@ -221,8 +221,10 @@ namespace Onion{
 		/**
 		 * @short Adds a listen point
 		 */
-		void addListenPoint(const std::string& hostname, const std::string& port, const ListenPoint& protocol) {
+		void addListenPoint(const std::string& hostname, const std::string& port, ListenPoint&& protocol) {
 			onion_add_listen_point(ptr, hostname.c_str(), port.c_str(), protocol.c_handler());
+                        // Release ownership of the pointer
+                        protocol.release();
 		}
 
 		/**


### PR DESCRIPTION
This should makes things seem more natural with memory management. If the user doesn't assign a ListenPoint to an Onion object, the listen point will be freed like expected. It's also clear what the ownership semantics are as well.