### PR TITLE
A memory leak is created when initializing the priority cache.

### DIFF
--- a/src/onion/https.c
+++ b/src/onion/https.c
@@ -135,7 +135,6 @@ onion_listen_point *onion_https_new(){
 		return NULL;
 	}
 	gnutls_certificate_set_dh_params (https->x509_cred, https->dh_params);
-	gnutls_priority_init (&https->priority_cache, "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0:%COMPAT", NULL); // PERFORMANCE:%SAFE_RENEGOTIATION:-VERS-TLS1.0:%COMPAT"
 	
 	ONION_DEBUG("HTTPS connection ready");
 	


### PR DESCRIPTION
In the https connector we are initializing the priority cache twice. This leaks memory. I chose to use the initialization line with the more secure settings as it seems SSL3 is on its way out. If these settings are wrong I can change them.