### PR TITLE
Fix memory leak when calling Onion::render_to_response.

### DIFF
--- a/src/bindings/cpp/shortcuts.cpp
+++ b/src/bindings/cpp/shortcuts.cpp
@@ -34,9 +34,7 @@
 onion_connection_status Onion::render_to_response(::Onion::template_f fn, const ::Onion::Dict& context, ::Onion::Response &res){
 	ONION_DEBUG("Context: %s", context.toJSON().c_str());
 
-	onion_dict *d=onion_dict_dup( context.c_handler() );
-	
-	fn(d, res.c_handler());
+	fn(context.c_handler(), res.c_handler());
 	
 	return OCS_PROCESSED;
 }


### PR DESCRIPTION
After the changes I made to the Onion::Dict class, we are unneccessarily
increasing the ref count on the context dict. This causes a memory leak
when calling Onion::render_to_response.