### PR TITLE
Fix build with libev.

### DIFF
--- a/examples/otop/CMakeLists.txt
+++ b/examples/otop/CMakeLists.txt
@@ -9,4 +9,8 @@ add_custom_command(
 add_executable(otop otop.c otop_data.c)
 target_link_libraries(otop onion  )
 
+if(${ONION_POLLER} STREQUAL "libev")
+	target_link_libraries(otop -lev)
+endif()
+
 install(TARGETS otop DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/onion/poller_libev.c
+++ b/src/onion/poller_libev.c
@@ -27,6 +27,7 @@
 
 #include "poller.h"
 #include "log.h"
+#include "low.h"
 
 struct onion_poller_t{
 	struct ev_loop *loop;


### PR DESCRIPTION
When building with libev on Fedora 23, otop isn't linking because of undefined references to libev functions. Also, I'm getting warnings about implicitly declared functions that reference onion_low* functions. This fixes that.