### PR TITLE
Fix locale dependency

### DIFF
--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdio.h>
-#include <inttypes.h>
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>
@@ -252,7 +251,7 @@ void onion_unquote_inplace(char *str){
 /**
  * @short Performs URL quoting, memory is allocated and has to be freed.
  *
- * As size necesary is dificult to measure, it first check how many should be encoded, and on a second round it encodes it.
+ * As size neccesary is difficult to measure, it first check how many should be encoded, and on a second round it encodes it.
  */
 char *onion_quote_new(const char *str){
 	int i;

--- a/src/onion/mime.c
+++ b/src/onion/mime.c
@@ -36,6 +36,10 @@ static onion_dict *onion_mime_dict=NULL;
 
 static void onion_mime_fill();
 
+// This macro is used to avoid undefined behavior when using the
+// ctype macros
+#define ONION_SAFETY_CAST(x) (int)(unsigned char){ x }
+
 /**
  * @short Sets a user set dict as mime dict
  * 
@@ -124,7 +128,7 @@ static void onion_mime_fill(){
 			i=0;
 		}
 		else{
-			if (isspace(c)){
+			if (isspace(ONION_SAFETY_CAST(c))){
 				if (mode==0){
 					mimetype[i]='\0';
 					mode=1;

--- a/src/onion/request.c
+++ b/src/onion/request.c
@@ -407,9 +407,9 @@ void onion_request_guess_session_id(onion_request *req){
  */
 onion_dict *onion_request_get_session_dict(onion_request *req){
 	if (!req->session){
-    if (req->flags & OR_HEADER_SENT){
-      ONION_WARNING("Asking for session AFTER sending headers. This may result in double sessionids, and wrong session behaviour. Please modify your handlers to ask for session BEFORE sending any data.");
-    }
+		if (req->flags & OR_HEADER_SENT){
+			ONION_WARNING("Asking for session AFTER sending headers. This may result in double sessionids, and wrong session behaviour. Please modify your handlers to ask for session BEFORE sending any data.");
+		}
 		onion_request_guess_session_id(req);
 		if (!req->session){ // Maybe old session is not to be used anymore
 			req->session_id=onion_sessions_create(req->connection.listen_point->server->sessions);
@@ -468,7 +468,7 @@ void onion_request_session_free(onion_request *req){
 	if (!req->session_id)
 		onion_request_guess_session_id(req);
 	if (req->session_id){
-    ONION_DEBUG("Removing from session storage session id: %s",req->session_id);
+		ONION_DEBUG("Removing from session storage session id: %s",req->session_id);
 		onion_sessions_remove(req->connection.listen_point->server->sessions, req->session_id);
 		onion_dict_free(req->session);
 		req->session=NULL;
@@ -524,8 +524,8 @@ const onion_block *onion_request_get_data(onion_request *req){
 onion_connection_status onion_request_process(onion_request *req){
 	onion_response *res=onion_response_new(req);
 	if (!req->path){
-    onion_request_polish(req);
-  }
+		onion_request_polish(req);
+	}
 	// Call the main handler.
 	onion_connection_status hs=onion_handler_handle(req->connection.listen_point->server->root_handler, req, res);
 
@@ -538,8 +538,8 @@ onion_connection_status onion_request_process(onion_request *req){
 			req->flags|=OR_NOT_IMPLEMENTED;
 		if (hs==OCS_NOT_PROCESSED)
 			req->flags|=OR_NOT_FOUND;
-    if (hs==OCS_FORBIDDEN)
-      req->flags|=OR_FORBIDDEN;
+		if (hs==OCS_FORBIDDEN)
+			req->flags|=OR_FORBIDDEN;
 
 		hs=onion_handler_handle(req->connection.listen_point->server->internal_error_handler, req, res);
 	}
@@ -567,10 +567,10 @@ onion_connection_status onion_request_process(onion_request *req){
  * @param req The request.
  */
 void onion_request_polish(onion_request *req){
-  if (*req->fullpath)
-    req->path=req->fullpath+1;
-  else
-    req->path=req->fullpath;
+	if (*req->fullpath)
+		req->path=req->fullpath+1;
+	else
+		req->path=req->fullpath;
 }
 
 /**
@@ -602,11 +602,11 @@ const char *onion_request_get_client_description(onion_request *req){
  * @returns Pointer to the stored sockaddr_storage.
  */
 struct sockaddr_storage *onion_request_get_sockadd_storage(onion_request *req, socklen_t *client_len){
-  if (client_len)
-    *client_len=req->connection.cli_len;
+	if (client_len)
+		*client_len=req->connection.cli_len;
 	if (req->connection.cli_len==0)
 		return NULL;
-  return &req->connection.cli_addr;
+	return &req->connection.cli_addr;
 }
 
 /**

--- a/src/onion/url.c
+++ b/src/onion/url.c
@@ -27,7 +27,6 @@
 #include <unistd.h>
 #include <regex.h>
 #include <stdio.h>
-#include <ctype.h>
 
 #include "log.h"
 #include "handler.h"


### PR DESCRIPTION
Onion shouldn't depend on the current locale for classifying characters, this should fix that. The one exception to this rule is when parsing /etc/mime.types, I don't think it matters in that case. Also, some formatting was fixed to be more consistent with the rest of the files.