### PR TITLE
localtime call isn't reentrant.

### DIFF
--- a/src/onion/log.c
+++ b/src/onion/log.c
@@ -154,8 +154,10 @@ void onion_log_stderr(onion_log_level level, const char *filename, int lineno, c
 
 	char datetime[32];
 	time_t t;
+	struct tm result;
 	t = time(NULL);
-	strftime(datetime, sizeof(datetime), "%Y-%m-%d %H:%M:%S", localtime(&t));
+	localtime_r(&t, &result);
+	strftime(datetime, sizeof(datetime), "%Y-%m-%d %H:%M:%S", &result);
 
 
 	strout_length+=sprintf(strout+strout_length, "[%s] [%s %s:%d] ", datetime, levelstr[level],


### PR DESCRIPTION
The localtime function uses a global data structure and a call to the
localtime function can clobber this when called from multiple threads
concurrently. I changed the call to localtime_r which uses a stack
allocated structure to store the data. This removes a data race
condition.