### PR TITLE
Fix a memory leak found in otemplate.

### DIFF
--- a/tools/otemplate/list.c
+++ b/tools/otemplate/list.c
@@ -36,7 +36,7 @@ void list_free(list *l){
 	void (*f)(void *p);
 	f=l->free;
 	while (i){
-		if (f)
+		if (f && (i->flags & LIST_ITEM_FREE))
 			f(i->data);
 		list_item *last_i=i;
 		i=i->next;
@@ -49,11 +49,25 @@ void list_add(list *l, void *p){
 	list_item *item=malloc(sizeof(list_item));
 	item->data=p;
 	item->next=NULL;
+	item->flags = LIST_ITEM_FREE;
 	item->prev=l->tail;
 	if (l->tail)
 		l->tail->next=item;
 	l->tail=item;
 	if (!l->head)
+		l->head=item;
+}
+
+void list_add_with_flags(list *l, void *p, int flags) {
+	list_item *item = malloc(sizeof(list_item));
+	item->data = p;
+	item->next=NULL;
+	item->flags = flags;
+	item->prev = l->tail;
+	if(l->tail)
+		l->tail->next=item;
+	l->tail = item;
+	if(!l->head)
 		l->head=item;
 }
 

--- a/tools/otemplate/list.h
+++ b/tools/otemplate/list.h
@@ -19,10 +19,16 @@
 #ifndef __LIST_H__
 #define __LIST_H__
 
+enum LIST_FREE_FLAGS {
+	LIST_ITEM_NO_FREE,
+	LIST_ITEM_FREE
+};
+
 typedef struct list_item_t{
 	void *data;
 	struct list_item_t *next;
 	struct list_item_t *prev;
+	int flags;
 }list_item;
 
 typedef struct list_t{
@@ -35,6 +41,7 @@ typedef struct list_t{
 list *list_new(void *free_function);
 void list_free(list *l);
 void list_add(list *l, void *p);
+void list_add_with_flags(list *l, void *p, int flags);
 void list_loop(list *l, void *f, void *extra);
 void list_pop(list *l);
 int list_count(list *l);

--- a/tools/otemplate/otemplate.c
+++ b/tools/otemplate/otemplate.c
@@ -40,7 +40,7 @@ void help(const char *msg);
 
 int main(int argc, char **argv){
 	// Add some plugin searhc paths
-	plugin_search_path=list_new(NULL);
+	plugin_search_path=list_new(free);
 
 	const char *infilename=NULL;
 	const char *outfilename=NULL;
@@ -111,8 +111,8 @@ int main(int argc, char **argv){
 	}
 
 	// Default template dirs
-	list_add(plugin_search_path, "lib%s.so");
-	list_add(plugin_search_path, "templatetags/lib%s.so");
+	list_add_with_flags(plugin_search_path, "lib%s.so", LIST_ITEM_NO_FREE);
+	list_add_with_flags(plugin_search_path, "templatetags/lib%s.so", LIST_ITEM_NO_FREE);
 	char tmp2[256];
 	strncpy(tmp2, argv[0], sizeof(tmp2)-1);
 	snprintf(tmp, sizeof(tmp), "%s/templatetags/lib%%s.so", dirname(tmp2));
@@ -120,8 +120,8 @@ int main(int argc, char **argv){
 	strncpy(tmp2, argv[0], sizeof(tmp2)-1);
 	snprintf(tmp, sizeof(tmp), "%s/lib%%s.so", dirname(tmp2));
 	list_add(plugin_search_path, strdup(tmp)); // dupa is ok, as im at main.
-	list_add(plugin_search_path, "/usr/local/lib/otemplate/templatetags/lib%s.so");
-	list_add(plugin_search_path, "/usr/lib/otemplate/templatetags/lib%s.so");
+	list_add_with_flags(plugin_search_path, "/usr/local/lib/otemplate/templatetags/lib%s.so", LIST_ITEM_NO_FREE);
+	list_add_with_flags(plugin_search_path, "/usr/lib/otemplate/templatetags/lib%s.so", LIST_ITEM_NO_FREE);
 
 	onion_assets_file *assetsfile=onion_assets_file_new(assetfilename);
 	int error=work(infilename, outfilename, assetsfile);


### PR DESCRIPTION
When compiling libonion with Clang's address sanitizer, this memory leak
prevents compilation due to otemplate leaking memory. This commit fixes the
memory leak.