### PR TITLE
Fix issue with html quoting and a buffer overflow.

### DIFF
--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -451,7 +451,7 @@ int onion_html_encoding_size(char c){
 		case '>':
 			return 4;
 		case '&':
-			return 4;
+			return 5;
 		case '"':
 			return 6;
 		case '\'':


### PR DESCRIPTION
We were incorrectly calculating the size of the new string, &amp; is 5
characters and not 4. This creates a buffer overflow condition in
onion_html_quote.