### PR TITLE
CentOS 6 SSL build

### DIFF
--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -403,8 +403,7 @@ void onion_sha1(const char *data, int length, char *result){
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
 #else
 	int hash_length = gcry_md_get_algo_dlen(GCRY_MD_SHA1);
-	unsigned char* hash = malloc(sizeof(char) * ((hash_length*2)+1));
-	gcry_md_hash_buffer(GCRY_MD_SHA1, hash, data, length);
+	gcry_md_hash_buffer(GCRY_MD_SHA1, hash, result, length);
 #endif
 #endif
 }

--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -402,7 +402,7 @@ void onion_sha1(const char *data, int length, char *result){
 #if GNUTLS_VERSION_NUMBER >= 0x021000
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
 #else
-	gcry_md_hash_buffer(GCRY_MD_SHA1, hash, result, length);
+	gcry_md_hash_buffer(GCRY_MD_SHA1, data, result, length);
 #endif
 #endif
 }

--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -27,7 +27,7 @@
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>
-#if GNUTLS_VERSION_NUMBER < 0x021000
+#if GNUTLS_VERSION_NUMBER < 0x020A00
 #include <gcrypt.h>
 #endif
 #endif
@@ -399,7 +399,7 @@ void onion_sha1(const char *data, int length, char *result){
 	ONION_ERROR("Cant calculate SHA1 if gnutls is not compiled in! Aborting now");
 	exit(1);
 #else
-#if GNUTLS_VERSION_NUMBER >= 0x021000
+#if GNUTLS_VERSION_NUMBER >= 0x020A00
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
 #else
 	gcry_md_hash_buffer(GCRY_MD_SHA1, result, data, length);

--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -402,7 +402,7 @@ void onion_sha1(const char *data, int length, char *result){
 #if GNUTLS_VERSION_NUMBER >= 0x021000
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
 #else
-	gcry_md_hash_buffer(GCRY_MD_SHA1, data, result, length);
+	gcry_md_hash_buffer(GCRY_MD_SHA1, result, data, length);
 #endif
 #endif
 }

--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -1,6 +1,6 @@
 /***
       Onion HTTP server library
-      Copyright (C) 2010-2015 David Moreno Montero and others
+      Copyright (C) 2010-2016 David Moreno Montero and others
 
       This library is free software; you can redistribute it and/or
       modify it under the terms of, at your choice:
@@ -27,6 +27,9 @@
 #ifdef HAVE_GNUTLS
 #include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>
+#if GNUTLS_VERSION_NUMBER < 0x021000
+#include <gcrypt.h>
+#endif
 #endif
 
 #include "low.h"
@@ -396,7 +399,13 @@ void onion_sha1(const char *data, int length, char *result){
 	ONION_ERROR("Cant calculate SHA1 if gnutls is not compiled in! Aborting now");
 	exit(1);
 #else
+#if GNUTLS_VERSION_NUMBER >= 0x021000
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
+#else
+	int hash_length = gcry_md_get_algo_dlen(GCRY_MD_SHA1);
+	unsigned char* hash = malloc(sizeof(char) * ((hash_length*2)+1));
+	gcry_md_hash_buffer(GCRY_MD_SHA1, hash, data, length);
+#endif
 #endif
 }
 

--- a/src/onion/codecs.c
+++ b/src/onion/codecs.c
@@ -402,7 +402,6 @@ void onion_sha1(const char *data, int length, char *result){
 #if GNUTLS_VERSION_NUMBER >= 0x021000
 	gnutls_hash_fast(GNUTLS_DIG_SHA1, data, length, result);
 #else
-	int hash_length = gcry_md_get_algo_dlen(GCRY_MD_SHA1);
 	gcry_md_hash_buffer(GCRY_MD_SHA1, hash, result, length);
 #endif
 #endif

--- a/src/onion/https.c
+++ b/src/onion/https.c
@@ -111,7 +111,7 @@ onion_listen_point *onion_https_new(){
 	// set cert here??
 	//onion_https_set_certificate(op,O_SSL_CERTIFICATE_KEY, "mycert.pem","mycert.pem");
 	int e;
-#if GNUTLS_VERSION_NUMBER >= 0x021200
+#if GNUTLS_VERSION_NUMBER >= 0x020C00
 	int bits = gnutls_sec_param_to_pk_bits (GNUTLS_PK_DH, GNUTLS_SEC_PARAM_LOW);
 #else
 	int bits = 1024;

--- a/src/onion/https.c
+++ b/src/onion/https.c
@@ -111,7 +111,11 @@ onion_listen_point *onion_https_new(){
 	// set cert here??
 	//onion_https_set_certificate(op,O_SSL_CERTIFICATE_KEY, "mycert.pem","mycert.pem");
 	int e;
+#if GNUTLS_VERSION_NUMBER >= 0x021200
 	int bits = gnutls_sec_param_to_pk_bits (GNUTLS_PK_DH, GNUTLS_SEC_PARAM_LOW);
+#else
+	int bits = 1024;
+#endif
 	e=gnutls_dh_params_init (&https->dh_params);
 	if (e<0){
 		ONION_ERROR("Error initializing HTTPS: %s", gnutls_strerror(e));

--- a/src/onion/random-gnutls.c
+++ b/src/onion/random-gnutls.c
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>
+#if GNULTLS_VERSION_NUMBER < 0x021200
+#include <gcrypt.h>
+#endif
 #include <assert.h>
 
 #include "types_internal.h"
@@ -80,5 +83,9 @@ void onion_random_free() {
  * Generate size bytes of random data and put on data
  */
 void onion_random_generate(void* data, size_t size) {
+#if GNUTLS_VERSION_NUMBER >= 0x021200
 	gnutls_rnd(GNUTLS_RND_NONCE,data,size);
+#else
+	gcry_create_nonce(data, size);
+#endif
 }

--- a/src/onion/random-gnutls.c
+++ b/src/onion/random-gnutls.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>
-#if GNULTLS_VERSION_NUMBER < 0x021200
+#if GNUTLS_VERSION_NUMBER < 0x020C00
 #include <gcrypt.h>
 #endif
 #include <assert.h>
@@ -83,7 +83,7 @@ void onion_random_free() {
  * Generate size bytes of random data and put on data
  */
 void onion_random_generate(void* data, size_t size) {
-#if GNUTLS_VERSION_NUMBER >= 0x021200
+#if GNUTLS_VERSION_NUMBER >= 0x020C00
 	gnutls_rnd(GNUTLS_RND_NONCE,data,size);
 #else
 	gcry_create_nonce(data, size);


### PR DESCRIPTION
When building onion on CentOS 6, the version of gnutls available is
ancient. This works around some missing functions not available in older
versions of gnutls.