### PR TITLE
Restore GCC 4.4 compatibility

### DIFF
--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -20,6 +20,13 @@
 #include <response.hpp>
 #include <url.hpp>
 
+#ifndef ONION_HAS_LAMBDAS
+onion_connection_status handle(Onion::Request &req, Onion::Response &res) {
+	res << "Non lambda handler";
+	return OCS_PROCESSED;
+}
+#endif
+
 int main(int argc, char **argv){
 	if (argc!=3){
 		ONION_ERROR("%s <certificate file> <key file>", argv[0]);
@@ -34,10 +41,14 @@ int main(int argc, char **argv){
 	Onion::Url root(&server);
 	
 	root.add("", "Some static text", HTTP_OK );
+#ifdef ONION_HAS_LAMBDAS
 	root.add("lambda", [](Onion::Request &req, Onion::Response &res){
 		res<<"Lambda handler";
 		return OCS_PROCESSED;
 	});
+#else
+	root.add("lambda", handle);
+#endif
 	
 	server.listen();
 }

--- a/src/bindings/cpp/CMakeLists.txt
+++ b/src/bindings/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(onioncpp SHARED dict.cpp handler.cpp extrahandlers.cpp url.cpp short
 add_library(onioncpp_static STATIC dict.cpp handler.cpp extrahandlers.cpp url.cpp shortcuts.cpp exceptions.cpp)
 SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++0x")
 
-SET(INCLUDES_ONIONCPP onion.hpp dict.hpp request.hpp response.hpp url.hpp handler.hpp extrahandlers.hpp shortcuts.hpp exceptions.hpp listen_point.hpp http.hpp https.hpp mime.hpp)
+SET(INCLUDES_ONIONCPP onion.hpp dict.hpp request.hpp response.hpp url.hpp handler.hpp extrahandlers.hpp shortcuts.hpp exceptions.hpp listen_point.hpp http.hpp https.hpp mime.hpp features.hpp)
 
 MESSAGE(STATUS "Found include files ${INCLUDES_ONIONCPP}")
 

--- a/src/bindings/cpp/dict.hpp
+++ b/src/bindings/cpp/dict.hpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -16,7 +16,7 @@
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
-	You should have received a copy of both libraries, if not see 
+	You should have received a copy of both licenses, if not see 
 	<http://www.gnu.org/licenses/> and 
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
@@ -31,6 +31,7 @@
 #include <onion/block.h>
 #include <map>
 #include <memory>
+#include "features.hpp"
 
 namespace Onion{
 	/**
@@ -46,7 +47,11 @@ namespace Onion{
 	 * it ensures copy of data and more memory use.
 	 */
 	class Dict{
+#if ONION_HAS_TEMPLATE_ALIAS
 		using internal_pointer = std::unique_ptr<onion_dict, decltype(onion_dict_free)*>;
+#else
+		typedef std::unique_ptr<onion_dict, decltype(onion_dict_free)*> internal_pointer;
+#endif
 		internal_pointer ptr;
 
 	public:
@@ -73,7 +78,9 @@ namespace Onion{
 			 * @short Create a lock object from a Dict.
 			 */
 			explicit lock(onion_dict* d) : dict(d) { }
+#if ONION_HAS_RVALUE_REFS
 			lock(lock&& l) : dict(l.dict) { l.dict = nullptr; }
+#endif
 
 			/**
 			 * @short Automatically releases a lock when the scope is exited.
@@ -88,6 +95,7 @@ namespace Onion{
 		 */
 		Dict(const std::map<std::string, std::string> &values);
 
+#if ONION_HAS_INIT_LIST 
 		/**
 		 * @short Created directly from initializer list. Only for > C++11
 		 * 
@@ -97,11 +105,13 @@ namespace Onion{
 		 * @endcode
 		 */
 		Dict(std::initializer_list<std::initializer_list<std::string>> &&init);
-
+#endif
 		/**
 		 * @short Creates an empty Onion::Dict
 		 */
-	    Dict() : ptr { onion_dict_new(), &onion_dict_free } {}
+	    Dict() :
+	    ptr { onion_dict_new(), &onion_dict_free } 
+	    {}
 
 		/**
 		 * @short Creates a Onion::Dict from a c onion_dict.
@@ -121,7 +131,7 @@ namespace Onion{
 		 * @short Frees this reference.
 		 */
 	    ~Dict() {}
-    
+
 	    /**
 		 * @short Try to get a key, if not existant, throws an key_not_found exception.
 		 */

--- a/src/bindings/cpp/extrahandlers.cpp
+++ b/src/bindings/cpp/extrahandlers.cpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and othes
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -16,7 +16,7 @@
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
-	You should have received a copy of both libraries, if not see 
+	You should have received a copy of both licenses, if not see 
 	<http://www.gnu.org/licenses/> and 
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
@@ -30,25 +30,54 @@
 
 using namespace Onion;
 
+#ifndef ONION_HAS_LAMBDAS
+	struct BoundFunction {
+		BoundFunction(const std::string& data, onion_connection_status (*func)(const char*, onion_request*, onion_response*))
+			: data(data) {
+			this->func = func;
+		}
+		onion_connection_status operator()(Onion::Request& req, Onion::Response& res) {
+			return onion_shortcut_response_file(data.c_str(), req.c_handler(), res.c_handler());
+		}
+		onion_connection_status (*func)(const char*, onion_request*, onion_response*);
+		std::string data;
+	};
+#endif
+
 Handler Shortcuts::static_file(const std::string& path)
 {
+#ifdef ONION_HAS_LAMBDAS
 	return Handler::make<HandlerFunction>([path](Onion::Request &req, Onion::Response &res){
 		return onion_shortcut_response_file(path.c_str(), req.c_handler(), res.c_handler()); 
 	});
+#else
+	std::shared_ptr<BoundFunction> bf { new BoundFunction(path, &onion_shortcut_response_file) };
+	return Handler::make<HandlerFunction>(std::bind(&BoundFunction::operator(), bf, std::placeholders::_1, std::placeholders::_2));
+#endif
 }
 
 Handler Shortcuts::internal_redirect(const std::string& uri)
 {
+#ifdef ONION_HAS_LAMBDAS
 	return Handler::make<HandlerFunction>([uri](Onion::Request &req, Onion::Response &res){
 		return onion_shortcut_internal_redirect(uri.c_str(), req.c_handler(), res.c_handler());
 	});
+#else
+	std::shared_ptr<BoundFunction> bf { new BoundFunction(uri, &onion_shortcut_internal_redirect) };
+	return Handler::make<HandlerFunction>(std::bind(&BoundFunction::operator(), bf, std::placeholders::_1, std::placeholders::_2));
+#endif
 }
 
 Handler Shortcuts::redirect(const std::string& uri)
 {
+#ifdef ONION_HAS_LAMBDAS
 	return new HandlerFunction([uri](Onion::Request &req, Onion::Response &res){
 		return onion_shortcut_redirect(uri.c_str(), req.c_handler(), res.c_handler());
 	});
+#else
+	std::shared_ptr<BoundFunction> bf { new BoundFunction(uri, &onion_shortcut_redirect) };
+	return Handler::make<HandlerFunction>(std::bind(&BoundFunction::operator(), bf, std::placeholders::_1, std::placeholders::_2));
+#endif
 }
 
 Handler StaticHandler(const std::string &path)

--- a/src/bindings/cpp/extrahandlers.hpp
+++ b/src/bindings/cpp/extrahandlers.hpp
@@ -31,6 +31,7 @@
 #include "handler.hpp"
 #include "request.hpp"
 #include "response.hpp"
+#include "features.hpp"
 
 namespace Onion{
 

--- a/src/bindings/cpp/features.hpp
+++ b/src/bindings/cpp/features.hpp
@@ -52,6 +52,20 @@
 #define ONION_HAS_RVALUE_REFS 1
 #define ONION_HAS_INIT_LIST 1
 #endif
+
+// End of GCC defines
+#elif defined(__clang__)
+// Any recent version of clang has more than enough support (> 2.9)
+#define ONION_HAS_LAMBDAS 1
+#define ONION_HAS_NOEXCEPT 1
+#define ONION_HAS_NULLPTR 1
+#define ONION_HAS_RANGED_FOR 1
+#define ONION_HAS_BRACED_INIT 1
+#define ONION_HAS_DEFAULT_FUNCS 1
+#define ONION_HAS_DELETED_FUNCS 1
+#define ONION_HAS_TEMPLATE_ALIAS 1
+#define ONION_HAS_RVALUE_REFS 1
+#define ONION_HAS_INIT_LIST 1
 #endif
 
 // Might as well approximate behavior for basic things

--- a/src/bindings/cpp/features.hpp
+++ b/src/bindings/cpp/features.hpp
@@ -1,0 +1,66 @@
+/*
+	Onion HTTP server library
+	Copyright (C) 2010-2016 David Moreno Montero and others
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of, at your choice:
+	
+	a. the Apache License Version 2.0.
+	
+	b. the GNU General Public License as published by the 
+		Free Software Foundation; either version 2.0 of the License
+		or (at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of both licenses, if not see 
+	<http://www.gnu.org/licenses/> and 
+	<http://www.apache.org/licenses/LICENSE-2.0>.
+	*/
+
+#ifndef ONION_FEATURES_HPP
+#define ONION_FEATURES_HPP
+
+#if !defined(__clang__) && defined(__GNUC__)
+// Check for < GCC 4.7, undefined for clarity
+#define ONION_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)
+
+#if ONION_GCC_VERSION < 40700
+#undef ONION_HAS_LAMBDAS			// No lambdas
+#undef ONION_HAS_NOEXCEPT			// No noexcept
+#undef ONION_HAS_NULLPTR			// No nullptr
+#undef ONION_HAS_RANGED_FOR			// No for(auto p : list)
+#define ONION_HAS_BRACED_INIT 1		// We can do int { 0 }
+#undef ONION_HAS_DEFAULT_FUNCS		// No Contructor() = default;
+#undef ONION_HAS_DELETED_FUNCS		// No Constructor() = deleted;
+#undef ONION_HAS_TEMPLATE_ALIAS		// No using type = othertype
+#define ONION_HAS_RVALUE_REFS 1		// We can do I&& i
+#define ONION_HAS_INIT_LIST 1		// We can do Clazz c { 0, 1, 2, 3, 4}
+#else
+// Greater than 4.7 has all the modern support we need
+#define ONION_HAS_LAMBDAS 1
+#define ONION_HAS_NOEXCEPT 1
+#define ONION_HAS_NULLPTR 1
+#define ONION_HAS_RANGED_FOR 1
+#define ONION_HAS_BRACED_INIT 1
+#define ONION_HAS_DEFAULT_FUNCS 1
+#define ONION_HAS_DELETED_FUNCS 1
+#define ONION_HAS_TEMPLATE_ALIAS 1
+#define ONION_HAS_RVALUE_REFS 1
+#define ONION_HAS_INIT_LIST 1
+#endif
+#endif
+
+// Might as well approximate behavior for basic things
+#ifndef ONION_HAS_NOEXCEPT
+#define noexcept throw()
+#endif
+
+#ifndef ONION_HAS_NULLPTR
+#define nullptr 0
+#endif
+
+#endif

--- a/src/bindings/cpp/handler.cpp
+++ b/src/bindings/cpp/handler.cpp
@@ -41,7 +41,7 @@ onion_handler *Onion::onion_handler_cpp_to_c(Handler handler){
 
 /// Converts a C handler to C++
 Handler Onion::onion_handler_c_to_cpp(onion_handler *h){
-	return std::move(Handler::make<HandlerCBridge>(h)); 
+	return Handler::make<HandlerCBridge>(h); 
 }
 
 static onion_connection_status onion_handler_call_operator(void *ptr, onion_request *_req, onion_response *_res){

--- a/src/bindings/cpp/handler.cpp
+++ b/src/bindings/cpp/handler.cpp
@@ -41,7 +41,7 @@ onion_handler *Onion::onion_handler_cpp_to_c(Handler handler){
 
 /// Converts a C handler to C++
 Handler Onion::onion_handler_c_to_cpp(onion_handler *h){
-	return Handler::make<HandlerCBridge>(h); 
+	return std::move(Handler::make<HandlerCBridge>(h)); 
 }
 
 static onion_connection_status onion_handler_call_operator(void *ptr, onion_request *_req, onion_response *_res){

--- a/src/bindings/cpp/listen_point.hpp
+++ b/src/bindings/cpp/listen_point.hpp
@@ -25,8 +25,15 @@
 
 #include <onion/listen_point.h>
 #include <memory>
+#include "features.hpp"
 
 namespace Onion {
+#ifndef ONION_HAS_LAMBDAS
+	static void listen_point_no_free(onion_listen_point*) {
+		return;
+	}
+#endif
+
 	/**
 	 * @short Creates a listen point for an Onion::Onion object.
 	 * Not meant to be used directly, as a default listen point doesn't
@@ -34,7 +41,11 @@ namespace Onion {
 	 */
 	class ListenPoint {
 	protected:
+#ifdef ONION_HAS_TEMPLATE_ALIAS
 		using internal_pointer = std::unique_ptr<onion_listen_point, decltype(onion_listen_point_free)*>;
+#else
+		typedef std::unique_ptr<onion_listen_point, decltype(onion_listen_point_free)*> internal_pointer;
+#endif
 		internal_pointer ptr;
 	public:
 		ListenPoint() 
@@ -42,7 +53,11 @@ namespace Onion {
 		{}
 
 		ListenPoint(onion_listen_point* lp)
+#ifdef ONION_HAS_LAMBDAS
 			: ptr(lp, [](onion_listen_point*) { return; })
+#else
+			: ptr(lp, &listen_point_no_free)
+#endif
 		{}
 
 		ListenPoint(ListenPoint&& other) : ptr { std::move(other.ptr) }

--- a/src/bindings/cpp/onion.hpp
+++ b/src/bindings/cpp/onion.hpp
@@ -26,6 +26,7 @@
 
 #include <string>
 #include <onion/onion.h>
+#include "features.hpp"
 #include "listen_point.hpp"
 #include "handler.hpp"
 
@@ -145,7 +146,7 @@ namespace Onion{
 		* Its a convenience function that converts the integer to a string.
 		*/
 		void setPort(int port){
-			std::string port_str=std::to_string(port);
+			std::string port_str=std::to_string(static_cast<long long int>(port));
 			onion_set_port(ptr,port_str.c_str());
 		}
 		

--- a/src/bindings/cpp/url.hpp
+++ b/src/bindings/cpp/url.hpp
@@ -24,6 +24,7 @@
 #ifndef ONION_URL_HPP
 #define ONION_URL_HPP
 
+#include "features.hpp"
 #include "onion.hpp"
 #include "handler.hpp"
 #include <onion/url.h>
@@ -67,7 +68,11 @@ namespace Onion{
 	 * As it can se regex without full matching, be careful or its possible to just match substrings: "o$" matches "Hello", "Hello/World/o" and so on.
 	 */
 	class Url{
+#ifdef ONION_HAS_TEMPLATE_ALIAS
 		using internal_pointer = std::unique_ptr<onion_url, decltype(onion_url_free)*>;
+#else
+		typedef std::unique_ptr<onion_url, decltype(onion_url_free)*> internal_pointer;
+#endif
 		internal_pointer ptr;
 	public:
 		/**

--- a/tests/01-internal/06-onion.c
+++ b/tests/01-internal/06-onion.c
@@ -359,7 +359,8 @@ onion_connection_status wait_random(void *_, onion_request *req, onion_response 
 
 void do_timeout_request(){
   ONION_INFO("Start timeout requests");
-  for (int i=0;i<10;i++){
+  int i;
+  for (i=0;i<10;i++){
     int fd=connect_to("localhost","8081");
     if ((i&1) == 1)
       usleep(500000);

--- a/tests/08-cpp/03-urls.cpp
+++ b/tests/08-cpp/03-urls.cpp
@@ -23,6 +23,34 @@
 #include "response.hpp"
 #include "shortcuts.hpp"
 
+#ifndef ONION_HAS_LAMBDAS
+onion_connection_status root_handler(Onion::Url& url, Onion::Request &req, Onion::Response &res) {
+	if(req.query().has("go"))
+		return url(req, res);
+	res << "<html><body>Go to <a href=\"?go\">?go</a>";
+	return OCS_PROCESSED;
+}
+
+onion_connection_status go(Onion::Request &req, Onion::Response &res) {
+	res << "Index, now try <a href=\"/more/?go\">/more</a>";
+	return OCS_PROCESSED;
+}
+
+onion_connection_status go_more(Onion::Url &more_url, Onion::Request& req, Onion::Response& res) {
+	return more_url(req, res);
+}
+
+onion_connection_status more(Onion::Request &req, Onion::Response &res) {
+	res << "more index, try <a href=\"/more/less?go\">Less</a>";
+	return OCS_PROCESSED;
+}
+
+onion_connection_status less(Onion::Request &req, Onion::Response &res) {
+	res << "More is less! (or was is <a href=\"/less/more?go\">less is more</a>?";
+	return OCS_PROCESSED;
+}
+#endif
+
 void t01_url(){
 	INIT_LOCAL();
 	
@@ -34,32 +62,53 @@ void t01_url(){
 	Onion::Url more_url2;
 	
 	// Set the main handler, does nothing if not called as ?go, if so, uses the url handler.
+#ifdef ONION_HAS_LAMBDAS
 	o.setRootHandler(Onion::Handler::make<Onion::HandlerFunction>([&url](Onion::Request &req, Onion::Response &res) -> onion_connection_status{
 		if (req.query().has("go"))
 			return url(req, res);
 		res<<"<html><body>Go to <a href=\"?go\">?go</a>";
 		return OCS_PROCESSED;
 	}));
+#else
+	o.setRootHandler(Onion::Handler::make<Onion::HandlerFunction>(std::bind(&root_handler, std::ref(url), std::placeholders::_1, std::placeholders::_2)));
+#endif
 
 
 	// Populate the url handler a little bit.
+#ifdef ONION_HAS_LAMBDAS
 	url.add("", [](Onion::Request &req, Onion::Response &res){
 		res<<"Index, now try <a href=\"/more/?go\">/more</a>";
 		return OCS_PROCESSED;
 	});
+#else
+	url.add("", std::bind(&go, std::placeholders::_1, std::placeholders::_2));
+#endif
 	
+#ifdef ONION_HAS_LAMBDAS
 	url.add("^more/", [&more_url](Onion::Request &req, Onion::Response &res){
 		return more_url(req, res);
 	});
+#else
+	url.add("^more/", std::bind(&go_more, std::ref(more_url), std::placeholders::_1, std::placeholders::_2));
+#endif
 	
+#ifdef ONION_HAS_LAMBDAS
 	more_url.add("", [](Onion::Request &req, Onion::Response &res){
 		res<<"more index, try <a href=\"/more/less?go\">Less</a>";
 		return OCS_PROCESSED;
 	});
+#else
+	more_url.add("", std::bind(&more, std::placeholders::_1, std::placeholders::_2));
+#endif
+
+#ifdef ONION_HAS_LAMBDAS
 	more_url.add("less", [](Onion::Request &req, Onion::Response &res){
 		res<<"More is less! (or was is <a href=\"/less/more?go\">less is more</a>?)";
 		return OCS_PROCESSED;
 	});
+#else
+	more_url.add("less", std::bind(&less, std::placeholders::_1, std::placeholders::_2));
+#endif
 	
 	url.add("^less/", std::move(more_url2));
 	

--- a/tests/08-cpp/04-templates.cpp
+++ b/tests/08-cpp/04-templates.cpp
@@ -25,6 +25,12 @@
 
 #include <assets.h>
 
+#ifndef ONION_HAS_LAMBDAS
+onion_connection_status template_render(Onion::Request &req, Onion::Response &res) {
+	return Onion::render_to_response(_04_templates_html, std::map<std::string,std::string>{{"test", "ok"}}, res);
+}
+#endif
+
 void t01_url(){
 	INIT_LOCAL();
 	
@@ -33,9 +39,13 @@ void t01_url(){
 	// Create an empty url handler
 	Onion::Url url(o);
 	
+#ifdef ONION_HAS_LAMBDAS
 	url.add("", [](Onion::Request &req, Onion::Response &res){
 		return Onion::render_to_response(_04_templates_html, std::map<std::string,std::string>{{"test","ok"}} , res);
 	});
+#else
+	url.add("", std::bind(&template_render, std::placeholders::_1, std::placeholders::_2));
+#endif
 	
 	o.listen();
 	


### PR DESCRIPTION
I'm not sure if we ever supported GCC 4.4, but this is needed to build on stock CentOS 6 machines. I chose the route of adding a feature detection header to keep things clean and simple, as just looking to see if __cplusplus >= 201103L isn't enough, as older compilers define that even if they don't fully support C++11. Also, GCC 4.4 doesn't support lambdas in any form, so that needed to be worked around.

I also updated all the C++ examples and tests to support GCC 4.4.