### PR TITLE
Race condition fixes using the shutdown() trick, timeout handling speedup, slots preallocation

### DIFF
--- a/src/onion/poller.c
+++ b/src/onion/poller.c
@@ -353,31 +353,6 @@ onion_poller_slot *onion_poller_get(onion_poller *poller, int fd){
 	return NULL;
 }
 
-#if 0
-/**
- * @short Gets the next timeout
- *
- * On edge cases could get a wrong timeout, but always old or new, so its ok.
- *
- * List must be locked by caller.
- */
-static int onion_poller_get_next_timeout(onion_poller *p){
-	onion_poller_slot *next;
-	int timeout=INT_MAX; // Ok, minimum wakeup , once per hour.
-	next=p->head;
-	while(next){
-		//ONION_DEBUG("Check %d %d %d", timeout, next->timeout, next->delta_timeout);
-		if (next->timeout_limit<timeout)
-			timeout=next->timeout_limit;
-
-		next=next->next;
-	}
-
-	//ONION_DEBUG("Next wakeup in %d ms, at least", timeout);
-	return timeout;
-}
-#endif
-
 // Max of events per loop. If not al consumed for next, so no prob.  right number uses less memory, and makes less calls.
 static size_t onion_poller_max_events=1;
 
@@ -401,9 +376,6 @@ void onion_poller_poll(onion_poller *p){
 #else
 	p->stop=0;
 #endif
-#if 0
-	int maxtime;
-#endif
 	time_t ctime, ptime = 0;
 	int timeout;
 #ifdef HAVE_PTHREADS
@@ -414,29 +386,10 @@ void onion_poller_poll(onion_poller *p){
 	char stop = !p->stop && p->head;
 #endif
 	while (stop){
-#if 0
-		ctime=time(NULL);
-		pthread_mutex_lock(&p->mutex);
-		maxtime=onion_poller_get_next_timeout(p);
-		pthread_mutex_unlock(&p->mutex);
-
-		timeout=maxtime-ctime;
-		if (timeout>3600)
-			timeout=3600000;
-		else
-			timeout*=1000;
-#else
 		timeout=1000;
-#endif
 		ONION_DEBUG0("Wait for %d ms", timeout);
 		int nfds = epoll_wait(p->fd, event, onion_poller_max_events, timeout);
-#if 0
-		int ctime_end=time(NULL);
-		ONION_DEBUG0("Current time is %d, limit is %d, timeout is %d. Waited for %d seconds", ctime, maxtime, timeout, ctime_end-ctime);
-    ctime=ctime_end;
-#else
 		ctime = time(NULL);
-#endif
 
 		if (ctime != ptime) {
 			ptime = ctime;
@@ -447,28 +400,8 @@ void onion_poller_poll(onion_poller *p){
 				next=next->next;
 				if (cur->timeout_limit <= ctime){
 					ONION_DEBUG0("Timeout on %d, was %d (ctime %d)", cur->fd, cur->timeout_limit, ctime);
-#if 0
-          int i;
-          for (i=0;i<nfds;i++){
-            onion_poller_slot *el=(onion_poller_slot*)event[i].data.ptr;
-            if (cur==el){ // If removed just one with event, make it ignore the event later.
-              ONION_DEBUG0("Ignoring event as it timeouted: %d", cur->fd);
-              event[i].data.ptr=NULL;
-            }
-          }
-#endif
 					cur->timeout_limit=INT_MAX;
-#if 0
-					if (cur->shutdown){
-						cur->shutdown(cur->shutdown_data);
-						onion_poller_slot_set_shutdown(cur,NULL,NULL);
-					}
-					// closed, do not even try to call it.
-					cur->f=NULL;
-					cur->data=NULL;
-#else
 					shutdown(cur->fd, SHUT_RD);
-#endif
 				}
 			}
 			pthread_mutex_unlock(&p->mutex);
@@ -505,14 +438,6 @@ void onion_poller_poll(onion_poller *p){
         ONION_DEBUG0("Calling handler: %s (%d)",bs[0], el->fd);
         onion_low_free(bs); /* This cannot be onion_low_free since from
 		     backtrace_symbols. */
-#endif
-#if 0
-	/* Sometimes, el->f happens to be null. We want to remove this
-	   polling in that weird case. */
-				if (el->f)
-				  n= el->f(el->data);
-				else
-				  n= -1;
 #endif
 				n = el->f(el->data);
 


### PR DESCRIPTION
Hi David!

This is the patch I posted to the onion-dev list a while ago.  It isn't exactly clean, but it does the job of making onion work for me seemingly reliably for now (and faster than before, too), and I am not currently aware of any remaining fd or data race conditions in the poller with this patch applied, assuming that the epoll one-shot property works perfectly.  (There may still be issues with fd's getting closed on error by other parts of onion, which would trigger races in the poller again.  You might want to look into that.)

I think the fixtimeouts branch is a dead-end (slow, and possibly a less complete fix), at least for the time being, and this patch should be merged instead.  This way, we can announce that there were those fatal reliability and security bugs when running with a thread pool and epoll, which are now believed to be fixed.  Further cleanups (such as getting rid of the #if 0'ed portions, some of which are actually unsafe, or/and making more invasive changes) can then proceed separately (and will require review and extensive re-testing, as it is all too easy to introduce race conditions again).  Maybe you'll need to make a numbered release after merging this patch and before further related changes, so that there is a released version that is (at least potentially) reliable and secure (unlike what we had before, and unlike what further changes might bring), even if still dirty under the hood.

Thanks,

Alexander