### PR TITLE
Allow external header management.

### DIFF
--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -224,6 +224,24 @@ void onion_response_set_code(onion_response *res, int  code){
 }
 
 /**
+ * @short Sets whether or not to allow the app to send additional headers
+ *
+ * If set to true the framework will not end the header section automatically,
+ * allowing the app to write additional headers on-the-fly. This also transfers
+ * responsibility for closing the headers section to the app.
+ *
+ * Use with caution, but can be convenient e.g. for proxying requests to CGI scripts.
+ *
+ * @memberof onion_response_t
+ */
+void onion_response_set_app_headers(onion_response *res, bool allow){
+	if (allow)
+		res->flags|=OR_APP_HEADERS;
+	else
+		res->flags&=~OR_APP_HEADERS;
+}
+
+/**
  * @short Helper that is called on each header, and writes the header
  * @memberof onion_response_t
  */
@@ -268,7 +286,7 @@ int onion_response_write_headers(onion_response *res){
 	if (res->request->flags&OR_HTTP11){
 		onion_response_printf(res, "HTTP/1.1 %d %s\r\n",res->code, onion_response_code_description(res->code));
 		//ONION_DEBUG("Response header: HTTP/1.1 %d %s\n",res->code, onion_response_code_description(res->code));
-		if (!(res->flags&OR_LENGTH_SET)  && onion_request_keep_alive(res->request)){
+		if (!(res->flags&OR_LENGTH_SET) && !(res->flags&OR_APP_HEADERS) && onion_request_keep_alive(res->request)){
 			onion_response_write(res, CONNECTION_CHUNK_ENCODING, sizeof(CONNECTION_CHUNK_ENCODING)-1);
 			chunked=1;
 		}
@@ -291,7 +309,8 @@ int onion_response_write_headers(onion_response *res){
 	if (res->request->session_id && (onion_dict_count(res->request->session)>0)) // I have session with something, tell user
 		onion_response_printf(res, "Set-Cookie: sessionid=%s; httponly; Path=/\n", res->request->session_id);
 
-	onion_response_write(res,"\r\n",2);
+	if (!(res->flags&OR_APP_HEADERS))
+		onion_response_write(res,"\r\n",2);
 
 	ONION_DEBUG0("Headers written");
 	res->sent_bytes=-res->buffer_pos; // the header size is not counted here. It will add again so start negative.

--- a/src/onion/response.h
+++ b/src/onion/response.h
@@ -27,6 +27,7 @@
 #include "types.h"
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -82,10 +83,11 @@ const char *onion_response_code_description(int code);
  * These flags are used internally by the resposnes, but they can be the responses themselves of the handler when appropiate.
  */
 enum onion_response_flags_e{
-	OR_KEEP_ALIVE=4, 				///< Return when want to keep alive. Please also set the proper headers, specifically set the length. Otherwise it will block server side until client closes connection.
-	OR_LENGTH_SET=2,				///< Response has set the length, so we may keep alive.
 	OR_CLOSE_CONNECTION=1,	///< The connection will be closed when processing finishes.
+	OR_LENGTH_SET=2,				///< Response has set the length, so we may keep alive.
+	OR_KEEP_ALIVE=4, 				///< Return when want to keep alive. Please also set the proper headers, specifically set the length. Otherwise it will block server side until client closes connection.
 	OR_SKIP_CONTENT=8,			///< This is set when the method is HEAD. @see onion_response_write_headers
+	OR_APP_HEADERS=16,			///< Do not end the headers section. Convenient for proxying to CGI apps writing their own headers.
 	OR_CHUNKED=32,					///< The data is to be sent using chunk encoding. Its on if no lenght is set.
 	OR_CONNECTION_UPGRADE=64, ///< The connection is upgraded (websockets).
   OR_HEADER_SENT=0x0200,  ///< The header has already been written. Its done automatically on first user write. Same id as OR_HEADER_SENT from onion_response_flags.
@@ -107,6 +109,8 @@ void onion_response_set_header(onion_response *res, const char *key, const char 
 void onion_response_set_length(onion_response *res, size_t length);
 /// Sets the return code
 void onion_response_set_code(onion_response *res, int code);
+/// Sets whether or not to allow the app to send additional headers
+void onion_response_set_app_headers(onion_response *res, bool allow);
 /// Gets the headers dictionary
 onion_dict *onion_response_get_headers(onion_response *res);
 /// Sets a new cookie


### PR DESCRIPTION
This introduces an option to have the framework hand over header management to
the application.  The header section will not be finished automatically and the
app can keep adding headers via the usual write functions. It also becomes the
app's responsibility to end the header section before sendind the body.

This option is useful to proxy requests to CGI apps, but can probably come in
handy in other situations as well.