### PR TITLE
This should address Issue #73.

### DIFF
--- a/src/bindings/cpp/handler.hpp
+++ b/src/bindings/cpp/handler.hpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -16,7 +16,7 @@
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
-	You should have received a copy of both libraries, if not see 
+	You should have received a copy of both licenses, if not see 
 	<http://www.gnu.org/licenses/> and 
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
@@ -52,8 +52,6 @@ namespace Onion{
 		HandlerBase &operator=(HandlerBase &o) = delete;
 	};
 
-	//using Handler=std::unique_ptr<HandlerBase>;
-	
 	class Handler{
 		std::unique_ptr<HandlerBase> ptr;
 	public:
@@ -77,8 +75,6 @@ namespace Onion{
 	
 	/// Converts a C handler to C++
 	Handler onion_handler_c_to_cpp(onion_handler *);
-	
-	
 	
 	/**
 	* @short Creates a handler that calls a method in an object.

--- a/src/bindings/cpp/url.cpp
+++ b/src/bindings/cpp/url.cpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -16,7 +16,7 @@
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
-	You should have received a copy of both libraries, if not see 
+	You should have received a copy of both licenses, if not see 
 	<http://www.gnu.org/licenses/> and 
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
@@ -26,29 +26,29 @@
 #include "response.hpp"
 
 Onion::Url::Url()
-	: ptr { onion_url_new(), &onion_url_free }
+	: Handler { new HandlerMethod<Url>(this, &::Onion::Url::operator()) }, ptr { onion_url_new(), &onion_url_free }
 {
 }
 
 Onion::Url::Url(onion_url* _ptr)
-	: ptr { _ptr, &onion_url_free }
+	: Handler { new HandlerMethod<Url>(this, &::Onion::Url::operator()) }, ptr { _ptr, &onion_url_free }
 {
 }
 
 Onion::Url::Url(Onion* o)
-	: ptr { onion_root_url(o->c_handler()), [](onion_url*) -> void {} }
+	: Handler { new HandlerMethod<Url>(this, &::Onion::Url::operator()) }, ptr { onion_root_url(o->c_handler()), [](onion_url*) -> void {} }
 {
 }
 
 Onion::Url::Url(Onion& o)
-	: ptr { onion_root_url(o.c_handler()), [](onion_url*) -> void {} }
+	: Handler{ new HandlerMethod<Url>(this, &::Onion::Url::operator()) }, ptr { onion_root_url(o.c_handler()), [](onion_url*) -> void {} }
 {
 }
 
 Onion::Url::Url(Url &&o)
-	: ptr { o.ptr.get(), &onion_url_free }
+	: Handler { new HandlerMethod<Url>(this, &::Onion::Url::operator()) }, ptr { o.ptr.get(), &onion_url_free }
 {
-  o.ptr.get_deleter() = [](onion_url*) -> void {};
+	o.ptr.get_deleter() = [](onion_url*) -> void {};
 }
 
 Onion::Url::~Url()
@@ -87,14 +87,6 @@ Onion::Url& Onion::Url::add(const std::string &url, const std::string& s, int ht
 Onion::Url& Onion::Url::add(const std::string& url, onion_handler_handler handler)
 {
 	return add(url, static_cast<Handler&&>(Handler::make<HandlerCFunction>(handler)));
-}
-
-//FIXME: Make sure this is correct
-Onion::Url& Onion::Url::add(const std::string& url, Url url_handler)
-{
-	add(url, onion_url_to_handler(url_handler.c_handler()));
-	url_handler.ptr.get_deleter() = [](onion_url*) -> void {};
-	return *this;
 }
 
 onion_connection_status Onion::Url::operator()(::Onion::Request& req, ::Onion::Response& res)

--- a/src/bindings/cpp/url.hpp
+++ b/src/bindings/cpp/url.hpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2014 David Moreno Montero and othes
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This library is free software; you can redistribute it and/or
 	modify it under the terms of, at your choice:
@@ -16,7 +16,7 @@
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
 
-	You should have received a copy of both libraries, if not see 
+	You should have received a copy of both licenses, if not see 
 	<http://www.gnu.org/licenses/> and 
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
@@ -66,7 +66,7 @@ namespace Onion{
 	 * 
 	 * As it can se regex without full matching, be careful or its possible to just match substrings: "o$" matches "Hello", "Hello/World/o" and so on.
 	 */
-	class Url{
+	class Url : public Handler {
 		using internal_pointer = std::unique_ptr<onion_url, decltype(onion_url_free)*>;
 		internal_pointer ptr;
 	public:
@@ -157,14 +157,7 @@ namespace Onion{
 		 * With this method is possible to use the C handlers as onion_webdav.
 		 */
 		Url &add(const std::string &url, onion_handler_handler handler);
-		/**
-		 * @short Adds an url that calls another Onion::Url.
-		 * 
-		 * With this method its possible to create Onion::Url hierachies, easing the modularization of
-		 * web applications.
-		 */
-		Url &add(const std::string &url, Url url_handler);
-		
+
 		/**
 		 * @short Allows to call am Onion::Url to continue the processing of this request.
 		 * 

--- a/tests/08-cpp/03-urls.cpp
+++ b/tests/08-cpp/03-urls.cpp
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010 David Moreno Montero
+	Copyright (C) 2010-2016 David Moreno Montero and others
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as
@@ -48,9 +48,7 @@ void t01_url(){
 		return OCS_PROCESSED;
 	});
 	
-	url.add("^more/", [&more_url](Onion::Request &req, Onion::Response &res){
-		return more_url(req, res);
-	});
+	url.add("^more/", std::move(more_url));
 	
 	more_url.add("", [](Onion::Request &req, Onion::Response &res){
 		res<<"more index, try <a href=\"/more/less?go\">Less</a>";


### PR DESCRIPTION
Url now inherits from Handler. Removed the add method for Url that takes a
universal reference to another Url, as this is not needed now, as a Url is a
Handler. Also, updated the test now that a lambda isn't needed to invoke a Url.