### PR TITLE
Bugfix in `onion_response_vprintf`

### DIFF
--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -466,8 +466,11 @@ ssize_t onion_response_printf(onion_response *res, const char *fmt, ...){
 ssize_t onion_response_vprintf(onion_response *res, const char *fmt, va_list args)
 {
 	char temp[512];
+    va_list argz;
 	int l;
-	l=vsnprintf(temp, sizeof(temp), fmt, args);
+    va_copy(argz, args);
+	l=vsnprintf(temp, sizeof(temp), fmt, argz);
+    va_end(argz);
 	if (l<0) {
 		ONION_ERROR("Invalid vprintf fmt");
 		return -1;
@@ -484,7 +487,7 @@ ssize_t onion_response_vprintf(onion_response *res, const char *fmt, va_list arg
 			ONION_ERROR("Could not reserve %d bytes", l+1);
 			return -1;
 		}
-		vsnprintf(buf, l, fmt, args);
+		vsnprintf(buf, l+1, fmt, args);
 		s = onion_response_write (res, buf, l);
 		onion_low_free (buf);
 		return s;


### PR DESCRIPTION
Hi!

Here is a simple bugfix for some quirks with inputs larger than 512 bytes in `response.c:onion_response_vprintf`:
- the `va_list args` parameter was used twice, which is an undefined behavior (see `man 3 va_copy`), leading to segfaults on my machine;
- the second `vsnprintf`’s output was truncated, leading to the sending of a NUL character.

Beware: I have been unable to run the tests (couldn’t find how to do in `README.md`), therefore this request might break everything…

Sincerely,