### PR TITLE
Chrome websocket fix and unit tests

### DIFF
--- a/examples/websockets/websockets.c
+++ b/examples/websockets/websockets.c
@@ -32,7 +32,8 @@ onion_connection_status websocket_example(void *data, onion_request *req, onion_
 			"<html><body><h1>Easy echo</h1><pre id=\"chat\"></pre>"
 			" <script>\ninit = function(){\nmsg=document.getElementById('msg');\nmsg.focus();\n\nws=new WebSocket('ws://'+window.location.host);\nws.onmessage=function(ev){\n document.getElementById('chat').textContent+=ev.data+'\\n';\n};}\n"
 			"window.addEventListener('load', init, false);\n</script>"
-			"<input type=\"text\" id=\"msg\" onchange=\"javascript:ws.send(msg.value); msg.select(); msg.focus();\"/>\n"
+			"<input type=\"text\" id=\"msg\" onchange=\"javascript:ws.send(msg.value); msg.select(); msg.focus();\"/><br/>\n"
+			"<button onclick='ws.close(1000);'>Close connection</button>"
 			"</body></html>");
 		
 		

--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -170,7 +170,7 @@ onion_connection_status onion_response_free(onion_response *res){
 
 	int r=OCS_CLOSE_CONNECTION;
 
-	// it is a rare ocassion that there is no request, but although unlikely, it may happend
+	// it is a rare ocasion that there is no request, but although unlikely, it may happen
 	if (req){
 		// keep alive only on HTTP/1.1.
 		ONION_DEBUG0("keep alive [req wants] %d && ([skip] %d || [lenght ok] %d==%d || [chunked] %d)",

--- a/src/onion/websocket.c
+++ b/src/onion/websocket.c
@@ -116,6 +116,7 @@ onion_websocket* onion_websocket_new(onion_request* req, onion_response *res)
 
 	onion_response_set_code(res, HTTP_SWITCH_PROTOCOL);
 	res->flags|=OR_CONNECTION_UPGRADE;
+	res->flags|=OR_LENGTH_SET; // Fix for Chrome to close cleanly websocket connections
 	onion_response_set_header(res, "Upgrade", "websocket");
 	if (ws_protocol)
 		onion_response_set_header(res, "Sec-Websocket-Procotol", ws_protocol);

--- a/src/onion/websocket.c
+++ b/src/onion/websocket.c
@@ -267,8 +267,11 @@ int onion_websocket_read(onion_websocket* ws, char* buffer, size_t len)
 	}
 	//ONION_DEBUG("Please, read %d bytes, %d ready", len, ws->data_left);
 	if (ws->data_left==0){
-		if (onion_websocket_read_packet_header(ws)<0){
-			ONION_ERROR("Error reading websocket header");
+		onion_connection_status status;
+		if ((status = onion_websocket_read_packet_header(ws))<0){
+			if(status == -2) 
+				return -2;
+			ONION_ERROR("Error reading websocket header (%i)", status);
 			return -1;
 		}
 	}
@@ -494,7 +497,7 @@ onion_connection_status onion_websocket_call(onion_websocket* ws)
 			if (ws->data_left==0){
 				onion_connection_status err=onion_websocket_read_packet_header(ws);
 				if (err<0){
-					ONION_ERROR("Error reading websocket header");
+					if(err != -2) ONION_ERROR("Error reading websocket header (%i)", err);
 					return err;
 				}
 			}

--- a/src/onion/websocket.h
+++ b/src/onion/websocket.h
@@ -38,7 +38,7 @@ extern "C"{
 onion_websocket *onion_websocket_new(onion_request *req, onion_response *res);
 /// When freed, the callback is invoked with a negative data length.
 void onion_websocket_free(onion_websocket *ws);
-void onion_websocket_close(onion_websocket *ws);
+void onion_websocket_close(onion_websocket *ws, char *status);
 
 void onion_websocket_set_callback(onion_websocket *ws, onion_websocket_callback_t cb);
 void onion_websocket_set_userdata(onion_websocket *ws, void *userdata, void (*free_userdata)(void *));

--- a/tests/01-internal/14-websockets.c
+++ b/tests/01-internal/14-websockets.c
@@ -19,6 +19,7 @@
 #include <onion/onion.h>
 #include <onion/http.h>
 #include <onion/websocket.h>
+#include <onion/types_internal.h>
 #include "../ctest.h"
 #include "buffer_listen_point.h"
 
@@ -27,6 +28,40 @@ struct ws_status_t{
 	int is_connected;
 };
 struct ws_status_t ws_status;
+
+char *ws_data_tmp = NULL;
+int ws_data_length = 0;
+
+typedef ssize_t (lpreader_sig_t)(onion_request *req, char *data, size_t len);
+typedef ssize_t (lpwriter_sig_t)(onion_request *req, const char *data, size_t len);
+
+void websocket_data_buffer_write(onion_request *req, const char *data, size_t len){
+	if(!ws_data_tmp){
+		ws_data_length = len;
+		ws_data_tmp = malloc(ws_data_length);
+		strncpy(ws_data_tmp, data, ws_data_length);
+	}
+	else {
+		char *tmp = malloc(ws_data_length+len);
+		strncpy(tmp, ws_data_tmp, ws_data_length);
+		strncpy(tmp+ws_data_length, data, len);
+		ws_data_length +=len;
+		free(ws_data_tmp);
+		ws_data_tmp = tmp;
+	}
+}
+
+int websocket_data_buffer_read(onion_request *req, char *data, size_t len){
+	if(!ws_data_tmp || !ws_data_length || !data) return 0;
+	int i;
+	for(i=0; i < ws_data_length; i++){
+		data[i] = ws_data_tmp[i];
+		if(i == len-1) break;
+	}
+	strncpy(ws_data_tmp, ws_data_tmp+i+1, ws_data_length-i);
+	ws_data_length -= i+1;
+	return i+1;
+}
 
 onion_connection_status ws_callback(void *privadata, onion_websocket *ws, ssize_t nbytes_ready){
 	return OCS_NEED_MORE_DATA;
@@ -55,8 +90,64 @@ onion *websocket_server_new(){
 	return o;
 }
 
+int websocket_forge_small_packet(char **buffer){
+	// Forge 120 bytes Data Packet
+	int length=120;
+	int header_length = 6;
+	*buffer = malloc(sizeof(char) * length);
+	char *buf = *buffer;
+	memset(*buffer, '\0', length);
+	buf[0]=0x81; // FIN flag to 1, opcode: 0x01; one message, of type text;
+	buf[1]=0x1 << 7; // MASK Flag to 1;
+	buf[1]+=length-header_length; // length: 113 bytes of Data;
+	// Next 4 bytes: Masking-key
+	buf[2]=0xF2;
+	buf[3]=0x05;
+	buf[4]=0xA0;
+	buf[5]=0x01;
+	// actual data
+	strncpy(&(buf[6]), "Some UTF-8-encoded chars which will be cut at the 117th char so I write some gap-filling text with no meaning until it is enough", length-header_length);
+
+	// Masking operation on data
+	int i;
+	for(i=0; i < length-header_length; i++){
+		buf[i+6]=buf[i+6] ^ buf[2+i%4];
+	}
+	fflush(stdout);
+	return length;
+}
+
+int websocket_forge_close_packet(char **buffer){
+	// Forge 120 bytes Data Packet
+	int length=8;
+	int header_length = 6;
+	*buffer = malloc(sizeof(char) * length);
+	char *buf = *buffer;
+	memset(*buffer, '\0', length);
+	buf[0]=0x88; // FIN flag to 1, opcode: 0x08
+	buf[1]=0x1 << 7; // MASK Flag to 1;
+	buf[1]+=length-header_length; // length: 2 bytes of Data;
+	// Next 4 bytes: Masking-key
+	buf[2]=0xF2;
+	buf[3]=0x05;
+	buf[4]=0xA0;
+	buf[5]=0x01;
+	// Status code masked with key:
+	buf[6]=0x03 ^ buf[2];
+	buf[7]=0xE8 ^ buf[3];
+
+	return length;
+}
+
 int onion_request_write0(onion_request *req, const char *data){
 	return onion_request_write(req,data,strlen(data));
+}
+
+onion_request *websocket_start_handshake(onion *o){
+	onion_request *req=onion_request_new(onion_get_listen_point(o, 0));
+	onion_request_write0(req,"GET /\nUpgrade: websocket\nSec-Websocket-Version: 13\nSec-Websocket-Key: My-key\n\n");
+	onion_request_process(req);
+	return req;
 }
 
 void t01_websocket_server_no_ws(){
@@ -93,12 +184,67 @@ void t02_websocket_server_w_ws(){
 	END_LOCAL();
 }
 
+void t03_websocket_server_receive_small_packet(){
+	INIT_LOCAL();
+	int length = 0, r = 0;
+	char *buffer = NULL, buffer2[114];
+	memset(&ws_status,0,sizeof(ws_status));
+	onion *o=websocket_server_new();
+	onion_request *req=websocket_start_handshake(o);
+	req->connection.listen_point->read = (lpreader_sig_t*)websocket_data_buffer_read;
+
+	onion_response *res = onion_response_new(req);
+	onion_websocket *ws = onion_websocket_new(req, res);
+
+	length = websocket_forge_small_packet((char **)&buffer);
+	websocket_data_buffer_write(req, buffer, length);
+	
+	r = onion_websocket_read(ws, (char *)&buffer2, 120);
+
+	buffer2[114] = '\0';
+	FAIL_IF_NOT_EQUAL_STR(buffer2, "Some UTF-8-encoded chars which will be cut at the 117th char so I write some gap-filling text with no meaning unti");
+
+	onion_websocket_free(ws);
+	onion_request_free(req);
+	onion_free(o);
+	END_LOCAL();
+}
+
+void t04_websocket_server_close_handshake(){
+	INIT_LOCAL();
+	int length = 0, r = 0;
+	unsigned char *buffer = NULL, buffer2[8];
+	onion *o=websocket_server_new();
+	onion_request *req=websocket_start_handshake(o);
+	req->connection.listen_point->read = (lpreader_sig_t*) websocket_data_buffer_read;
+	req->connection.listen_point->write = (lpwriter_sig_t*) websocket_data_buffer_write;
+
+	onion_response *res = onion_response_new(req);
+	onion_websocket *ws = onion_websocket_new(req, res);
+
+	length = websocket_forge_close_packet((char **)&buffer);
+	websocket_data_buffer_write(req, buffer, length);
+	onion_connection_status ret = onion_websocket_call(ws);
+	FAIL_IF(ret!=-2);
+	websocket_data_buffer_read(req, (char *)&buffer2, 8);
+	FAIL_IF_NOT(buffer2[0]==0x88);
+	FAIL_IF_NOT(buffer2[1]==0x02);
+	FAIL_IF_NOT(buffer2[2]==0x03);
+	FAIL_IF_NOT(buffer2[3]==0xE8);
+
+	onion_websocket_free(ws);
+	onion_request_free(req);
+	onion_free(o);
+	END_LOCAL();
+}
 
 int main(int argc, char **argv){
 	START();
 
 	t01_websocket_server_no_ws();
 	t02_websocket_server_w_ws();
+	t03_websocket_server_receive_small_packet();
+	t04_websocket_server_close_handshake();
 
 	END();
 }


### PR DESCRIPTION
Hi, 

With chrome 51 when closing websocket from the client by doing ws.close(1000), an error is thrown:

> WebSocket connection to 'ws://localhost:8080/' failed: Received a broken close frame containing invalid UTF-8.

I fixed this error, and another appeared:
> WebSocket connection to 'ws://localhost:3000/' failed: One or more reserved bits are on: reserved1 = 0, reserved2 = 1, reserved3 = 1

Putting the OR_LENGTH_SET flag to all WS connections did resolve the issue.

To reproduce the issue:

1. Compile the examples/websockets.c with a button that does ws.close(1000); (or use my modified version)
2. Launch ./websockets 
3. Launch http://localhost:8080/ with Chrome 51.0.2704.79 (64-bit)
4. Open the log console
5. Close the WebSocket from the server

I also made some unit tests to check that websocket closing handshake and masking/unmasking are OK.

I hope this will be useful.