### PR TITLE
Fixes #119

### DIFF
--- a/src/onion/poller_libevent.c
+++ b/src/onion/poller_libevent.c
@@ -33,7 +33,7 @@
 
 struct onion_poller_t{
 	struct event_base *base;
-	sem_t sem;
+	sem_t *sem;
 	volatile int stop;
 };
 
@@ -90,13 +90,15 @@ onion_poller *onion_poller_new(int aprox_n){
 	
 	onion_poller *ret=calloc(1,sizeof(onion_poller));
 	ret->base=event_base_new();
-	sem_init(&ret->sem, 0, 1);
+	ret->sem=sem_init("/poller", O_CREAT, 0, 1);
 	return ret;
 }
 
 /// Frees the poller. It first stops it.
 void onion_poller_free(onion_poller *p){
 	event_base_free(p->base);
+	sem_close(p->sem);
+	sem_unlink("/poller");
 	free(p);
 }
 
@@ -133,9 +135,9 @@ int onion_poller_remove(onion_poller *poller, int fd){
 void onion_poller_poll(onion_poller *poller){
 	poller->stop=0;
 	while(!poller->stop){
-		sem_wait(&poller->sem);
+		sem_wait(poller->sem);
 		event_base_loop(poller->base,EVLOOP_ONCE);
-		sem_post(&poller->sem);
+		sem_post(poller->sem);
 	}
 }
 /// Stops the polling. This only marks the flag, and should be cancelled with pthread_cancel.


### PR DESCRIPTION
Uses named semaphores instead of unnamed semaphores as unnamed semaphores are deprecated for MAC OSX (http://stackoverflow.com/questions/1413785/sem-init-on-os-x).

I have kept the name of the semaphore to be "/poller". I checked all that most of the test cases were passing. On my system 11, 13 and 17 failed due to some reason but they were failing too even before the changes were made, I am still looking into the matter on why they failed or how can they be resolved.