### PR TITLE
Define C++ extra handlers in the correct namespace to fix linking

### DIFF
--- a/src/bindings/cpp/extrahandlers.cpp
+++ b/src/bindings/cpp/extrahandlers.cpp
@@ -28,41 +28,42 @@
 
 #include <onion/shortcuts.h>
 
-using namespace Onion;
+namespace Onion{
+	namespace Shortcuts{
+		Handler static_file(const std::string& path)
+		{
+			return Handler::make<HandlerFunction>([path](Onion::Request &req, Onion::Response &res){
+				return onion_shortcut_response_file(path.c_str(), req.c_handler(), res.c_handler());
+			});
+		}
 
-Handler Shortcuts::static_file(const std::string& path)
-{
-	return Handler::make<HandlerFunction>([path](Onion::Request &req, Onion::Response &res){
-		return onion_shortcut_response_file(path.c_str(), req.c_handler(), res.c_handler()); 
-	});
+		Handler internal_redirect(const std::string& uri)
+		{
+			return Handler::make<HandlerFunction>([uri](Onion::Request &req, Onion::Response &res){
+				return onion_shortcut_internal_redirect(uri.c_str(), req.c_handler(), res.c_handler());
+			});
+		}
+
+		Handler redirect(const std::string& uri)
+		{
+			return new HandlerFunction([uri](Onion::Request &req, Onion::Response &res){
+				return onion_shortcut_redirect(uri.c_str(), req.c_handler(), res.c_handler());
+			});
+		}
+	}
+
+	Handler StaticHandler(const std::string &path)
+	{
+		return Shortcuts::static_file(path);
+	}
+
+	Handler InternalRedirectHandler(const std::string& uri)
+	{
+		return Shortcuts::internal_redirect(uri);
+	}
+
+	Handler RedirectHandler(const std::string& uri)
+	{
+		return Shortcuts::redirect(uri);
+	}
 }
-
-Handler Shortcuts::internal_redirect(const std::string& uri)
-{
-	return Handler::make<HandlerFunction>([uri](Onion::Request &req, Onion::Response &res){
-		return onion_shortcut_internal_redirect(uri.c_str(), req.c_handler(), res.c_handler());
-	});
-}
-
-Handler Shortcuts::redirect(const std::string& uri)
-{
-	return new HandlerFunction([uri](Onion::Request &req, Onion::Response &res){
-		return onion_shortcut_redirect(uri.c_str(), req.c_handler(), res.c_handler());
-	});
-}
-
-Handler StaticHandler(const std::string &path)
-{
-	return Shortcuts::static_file(path);
-}
-
-Handler InternalRedirectHandler(const std::string& uri)
-{
-	return Shortcuts::internal_redirect(uri);
-}
-
-Handler RedirectHandler(const std::string& uri)
-{
-	return Shortcuts::redirect(uri);
-}
-


### PR DESCRIPTION
The extra handlers used to be defined in the global namespace rather than Onion, so client code would compile against the headers, but throw up undefined references at link time. This patch defines the handlers in Onion so that linking succeeds.