### PR TITLE
auth_pam.c: sprintf in stdio.h

### DIFF
--- a/src/onion/handlers/auth_pam.c
+++ b/src/onion/handlers/auth_pam.c
@@ -21,6 +21,7 @@
 	<http://www.apache.org/licenses/LICENSE-2.0>.
 	*/
 
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
Hello,

When I am compiling onion on my box, I am getting next warnings (actually, it may lead to errors as you know):
```
onion/src/onion/handlers/auth_pam.c: In function ‘onion_handler_auth_pam_handler’:
onion/src/onion/handlers/auth_pam.c:93: warning: implicit declaration of function ‘sprintf’
onion/src/onion/handlers/auth_pam.c:93: warning: incompatible implicit declaration of built-in function ‘sprintf’
```

The problem is that the file `<stdio.h>` is not included.

```
% cat /etc/redhat-release
CentOS release 6.9 (Final)
% uname -a
Linux localhost.localdomain 2.6.32-696.6.3.el6.x86_64 #1 SMP Wed Jul 12 14:17:22 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
% gcc -v
Using built-in specs.
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-languages=c,c++,objc,obj-c++,java,fortran,ada --enable-java-awt=gtk --disable-dssi --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-1.5.0.0/jre --enable-libgcj-multifile --enable-java-maintainer-mode --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libjava-multilib --with-ppl --with-cloog --with-tune=generic --with-arch_32=i686 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.4.7 20120313 (Red Hat 4.4.7-18) (GCC)
```

Thanks!