### PR TITLE
Add opack_static() back into oterm example

### DIFF
--- a/examples/oterm/oterm.c
+++ b/examples/oterm/oterm.c
@@ -42,6 +42,7 @@
 #include <onion/shortcuts.h>
 
 #include <assets.h>
+onion_connection_status opack_static(void *_, onion_request *req, onion_response *res);
 
 onion *o=NULL;
 


### PR DESCRIPTION
oterm example now compiles on Manjaro Linux

Not sure why this was removed, but the example seems to work now