### PR TITLE
    Add ability to skip and parse with {# template comments #}

### DIFF
--- a/tools/otemplate/parser.c
+++ b/tools/otemplate/parser.c
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2011 David Moreno Montero
+	Copyright (C) 2010-2018 David Moreno Montero and contributors
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as
@@ -16,6 +16,7 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	*/
 
+// indented with GNU indent: indent -gnu parser.c
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,72 +30,95 @@
 #include "variables.h"
 
 /// Set current parser status
-static void set_mode(parser_status *status, int mode);
+static void set_mode (parser_status * status, int mode);
 
 /**
  * @short Main parsing loop.
  */
-void parse_template(parser_status *status){
-	int c;
-	while ( (c=fgetc(status->in)) != EOF){
-		status->c=c;
-		if (c=='\n')
-			status->line++;
-		switch(status->mode){
-			case TEXT:
-				if (c=='{')
-					set_mode(status, BEGIN);
-				else
-					add_char(status, c);
-				break;
-			case BEGIN:
-				if (c=='{')
-					set_mode(status, VARIABLE);
-				else if (c=='%')
-					set_mode(status, TAG);
-				else{
-					set_mode(status, TEXT);
-					add_char(status, '{');
-					add_char(status, c);
-				}
-				break;
-			case VARIABLE:
-				if (c=='}')
-					set_mode(status, END_VARIABLE);
-				else
-					add_char(status, c);
-				break;
-			case TAG:
-				if (c=='%')
-					set_mode(status, END_TAG);
-				else
-					add_char(status, c);
-				break;
-			case END_VARIABLE:
-				if (c=='}')
-					set_mode(status, TEXT);
-				else{
-					set_mode(status, VARIABLE);
-					add_char(status, '}');
-					add_char(status, c);
-				}
-				break;
-			case END_TAG:
-				if (c=='}')
-					set_mode(status, TEXT);
-				else{
-					set_mode(status, END_TAG);
-					add_char(status, '%');
-					add_char(status, c);
-				}
-				break;
-			default:
-				ONION_ERROR("Unknown mode %d",status->mode);
-				status->status=1;
-				return;
-		}
+void
+parse_template (parser_status * status)
+{
+  int c;
+  while ((c = fgetc (status->in)) != EOF)
+    {
+      status->c = c;
+      if (c == '\n')
+	{
+	  if (status->mode == COMMENT || status->mode == COMMENTHASH)
+	    ONION_ERROR ("unterminated comment line %d", status->line);
+	  status->line++;
+	};
+      switch (status->mode)
+	{
+	case TEXT:
+	  if (c == '{')
+	    set_mode (status, BEGIN);
+	  else
+	    add_char (status, c);
+	  break;
+	case BEGIN:
+	  if (c == '{')
+	    set_mode (status, VARIABLE);
+	  else if (c == '%')
+	    set_mode (status, TAG);
+	  else if (c == '#')
+	    set_mode (status, COMMENT);
+	  else
+	    {
+	      set_mode (status, TEXT);
+	      add_char (status, '{');
+	      add_char (status, c);
+	    }
+	  break;
+	case COMMENT:
+	  if (c == '#')
+	    set_mode (status, COMMENTHASH);
+	  break;
+	case COMMENTHASH:
+	  if (c == '}')
+	    set_mode (status, TEXT);
+	  else
+	    set_mode (status, COMMENT);
+	  break;
+	case VARIABLE:
+	  if (c == '}')
+	    set_mode (status, END_VARIABLE);
+	  else
+	    add_char (status, c);
+	  break;
+	case TAG:
+	  if (c == '%')
+	    set_mode (status, END_TAG);
+	  else
+	    add_char (status, c);
+	  break;
+	case END_VARIABLE:
+	  if (c == '}')
+	    set_mode (status, TEXT);
+	  else
+	    {
+	      set_mode (status, VARIABLE);
+	      add_char (status, '}');
+	      add_char (status, c);
+	    }
+	  break;
+	case END_TAG:
+	  if (c == '}')
+	    set_mode (status, TEXT);
+	  else
+	    {
+	      set_mode (status, END_TAG);
+	      add_char (status, '%');
+	      add_char (status, c);
+	    }
+	  break;
+	default:
+	  ONION_ERROR ("Unknown mode %d", status->mode);
+	  status->status = 1;
+	  return;
 	}
-	set_mode(status, END);
+    }
+  set_mode (status, END);
 }
 
 /**
@@ -102,68 +126,79 @@ void parse_template(parser_status *status){
  * 
  * Depending on the mode of the block it calls the appropiate handler: variable, tag or just write text.
  */
-void write_block(parser_status *st, onion_block *b){
-	int mode=st->last_wmode;
-	//ONION_DEBUG("Write mode %d, code %s", mode, b->data);
-	switch(mode){
-		case TEXT:
-		{
-			int oldl;
-			if ( (oldl=onion_block_size(b)) ){
-				if (oldl>0){ // Not Just \0
-					int use_orig_line_numbers_bak=use_orig_line_numbers;
-					use_orig_line_numbers=0;
-					char *safe=onion_c_quote_new(onion_block_data(b));
-					function_add_code(st, "  onion_response_write(res, ");
-					int pos=0;
-					int size=strlen(safe);
-					char *s=safe;
-					//ONION_DEBUG("------- pos %d, size %d",pos,size);
-					while (pos<size){
-						//ONION_DEBUG("pos %d, size %d",pos,size);
-						char *e=strstr(s, "\n");
-						if (!e)
-							break;
-						*e='\0';
-						if (pos==0)
-							function_add_code(st, "%s\n", s);
-						else
-							function_add_code(st, "      %s\n", s);
-						pos+=(e-s)+1;
-						s=e+1;
-					}
-					if (pos==0)
-						function_add_code(st, "%s, %d);\n", s, oldl);
-					else
-						function_add_code(st, "      %s, %d);\n", s, oldl);
-					use_orig_line_numbers=use_orig_line_numbers_bak;
-					free(safe);
-				}
-			}
-		}
-			break;
-		case VARIABLE:
-			variable_write(st, b);
-			break;
-		case TAG:
-			tag_write(st, b);
-			break;
-		default:
-			ONION_ERROR("Unknown final mode %d", mode);
-	}
-	onion_block_clear(st->rawblock);
+void
+write_block (parser_status * st, onion_block * b)
+{
+  int mode = st->last_wmode;
+  //ONION_DEBUG("Write mode %d, code %s", mode, b->data);
+  switch (mode)
+    {
+    case TEXT:
+      {
+	int oldl;
+	if ((oldl = onion_block_size (b)))
+	  {
+	    if (oldl > 0)
+	      {			// Not Just \0
+		int use_orig_line_numbers_bak = use_orig_line_numbers;
+		use_orig_line_numbers = 0;
+		char *safe = onion_c_quote_new (onion_block_data (b));
+		function_add_code (st, "  onion_response_write(res, ");
+		int pos = 0;
+		int size = strlen (safe);
+		char *s = safe;
+		//ONION_DEBUG("------- pos %d, size %d",pos,size);
+		while (pos < size)
+		  {
+		    //ONION_DEBUG("pos %d, size %d",pos,size);
+		    char *e = strstr (s, "\n");
+		    if (!e)
+		      break;
+		    *e = '\0';
+		    if (pos == 0)
+		      function_add_code (st, "%s\n", s);
+		    else
+		      function_add_code (st, "      %s\n", s);
+		    pos += (e - s) + 1;
+		    s = e + 1;
+		  }
+		if (pos == 0)
+		  function_add_code (st, "%s, %d);\n", s, oldl);
+		else
+		  function_add_code (st, "      %s, %d);\n", s, oldl);
+		use_orig_line_numbers = use_orig_line_numbers_bak;
+		free (safe);
+	      }
+	  }
+      }
+      break;
+    case VARIABLE:
+      variable_write (st, b);
+      break;
+    case TAG:
+      tag_write (st, b);
+      break;
+    default:
+      ONION_ERROR ("Unknown final mode %d line %d", mode, st->line);
+    }
+  onion_block_clear (st->rawblock);
 }
 
 /// Read a char from the st->in-
-void add_char(parser_status *st, char c){
-	onion_block_add_char(st->rawblock, c);
+void
+add_char (parser_status * st, char c)
+{
+  onion_block_add_char (st->rawblock, c);
 }
 
 /// Mode change, depending of the mode, may indicate that a block must be written
-void set_mode(parser_status *status, int mode){
-	if (mode<16){
-		write_block(status, status->rawblock);
-		status->last_wmode=mode;
-	}
-	status->mode=mode;
+void
+set_mode (parser_status * status, int mode)
+{
+  if (mode < TRANSITIONAL_MODE_THRESHOLD)
+    {
+      write_block (status, status->rawblock);
+      status->last_wmode = mode;
+    }
+  status->mode = mode;
 }

--- a/tools/otemplate/parser.h
+++ b/tools/otemplate/parser.h
@@ -1,6 +1,6 @@
 /*
 	Onion HTTP server library
-	Copyright (C) 2010-2011 David Moreno Montero
+	Copyright (C) 2010-2018 David Moreno Montero and contributors
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as
@@ -26,45 +26,51 @@
 #include "functions.h"
 #include "list.h"
 
-typedef enum parser_mode_e{
-	TEXT=0,
-	VARIABLE=2,
-	TAG=3,
-	
-	END=15,
-	// transitional modes
-	BEGIN=17,
-	END_VARIABLE=18,
-	END_TAG=19,
-	
-}parser_mode;
+typedef enum parser_mode_e
+{
+  TEXT = 0,
+  VARIABLE = 2,
+  TAG = 3,
+
+  END = 15,
+
+  TRANSITIONAL_MODE_THRESHOLD = 16,
+  // transitional modes
+  BEGIN = 17,
+  END_VARIABLE = 18,
+  END_TAG = 19,
+  COMMENT = 20,			// inside comments
+  COMMENTHASH = 21,		// got an hash in a comment
+
+} parser_mode;
 
 
-struct parser_status_t{
-	parser_mode last_wmode;
-	parser_mode mode;
-	FILE *in;
-	FILE *out;
-	
-	const char *infilename; /// Needed for includes using relative path
-	
-	onion_block *rawblock; /// Current block of data as readed by the parser.
-	
-	list *functions; /// List of all known functions
-	list *function_stack; /// Current stack of functions, to know where to write.
-	function_data *blocks_init; /// List of block names
-	onion_block *current_code; /// Blocks of C code to be printed. this is final code.
-	char c; /// Last character read
-	int status; /// Exit status.
-	int function_count;
-	int line;
+struct parser_status_t
+{
+  parser_mode last_wmode;
+  parser_mode mode;
+  FILE *in;
+  FILE *out;
+
+  const char *infilename;	/// Needed for includes using relative path
+
+  onion_block *rawblock;	/// Current block of data as readed by the parser.
+
+  list *functions;		/// List of all known functions
+  list *function_stack;		/// Current stack of functions, to know where to write.
+  function_data *blocks_init;	/// List of block names
+  onion_block *current_code;	/// Blocks of C code to be printed. this is final code.
+  char c;			/// Last character read
+  int status;			/// Exit status.
+  int function_count;
+  int line;
 };
 typedef struct parser_status_t parser_status;
 
-void parse_template(parser_status *status);
+void parse_template (parser_status * status);
 
-void add_char(parser_status *st, char c);
-void write_block(parser_status *st, onion_block *b);
+void add_char (parser_status * st, char c);
+void write_block (parser_status * st, onion_block * b);
 
 
 #endif


### PR DESCRIPTION
    Fix issue #224

    The source code of parser.c & parser.h has been indented in GNU style with indent -gnu