### PR TITLE
Fix gcc 8 warning about MEMORY_FAILURE macro

### DIFF
--- a/src/onion/low.c
+++ b/src/onion/low.c
@@ -66,7 +66,7 @@ static onion_low_pthread_sigmask_sigt *thrsigmask_onion_f = pthread_sigmask;
 
 /* macro in case of memory failure. */
 #define MEMORY_FAILURE(Fmt,...) do {			\
-  char errmsg[48];					\
+  char errmsg[50];					\
   memset (errmsg, 0, sizeof(errmsg));			\
   snprintf (errmsg, sizeof(errmsg), Fmt, __VA_ARGS__);	\
   memoryfailure_onion_f (errmsg);			\


### PR DESCRIPTION
In usage from low.c line 139, `snprintf` output could be between 32 and 50 bytes with `%ld` flag

This is the last warning that I'm seeing when compiling libonion as a subproject, excluding the tests folder