### PR TITLE
Handlers for uploaded files, handlers for calculating hash

### DIFF
--- a/src/onion/http.c
+++ b/src/onion/http.c
@@ -62,18 +62,21 @@ onion_listen_point *onion_http_new() {
   ret->mks_att = mkstemp;
   ret->write_att = write;
   ret->close_att = close;
+  ret->unlink_att = unlink;
 
   return ret;
 }
 
 
-void onion_set_attachment_handlers(onion_listen_point* lp,
+void onion_set_attachment_handlers(onion_listen_point* ret,
       int (*f_open)(char*),
       ssize_t (*f_write)(int, const void*, size_t),
-      int (*f_close)(int) ){
-  lp->mks_att = f_open;     //mkstemp;
-  lp->write_att = f_write;  //write;
-  lp->close_att = f_close;  //close;
+      int (*f_close)(int),
+      int (*f_unlink)(const char*)){
+  ret->mks_att = f_open;       //mkstemp;
+  ret->write_att = f_write;    //write;
+  ret->close_att = f_close;    //close;
+  ret->unlink_att = f_unlink;  //unlink
 }
 
 

--- a/src/onion/http.c
+++ b/src/onion/http.c
@@ -44,6 +44,7 @@ int onion_http_read_ready(onion_request * req);
 struct onion_http_t {
 };
 
+
 /**
  * @short Creates an HTTP listen point
  * @memberof onion_http_t
@@ -58,24 +59,22 @@ onion_listen_point *onion_http_new() {
   ret->read_ready = onion_http_read_ready;
   ret->secure = false;
 
-  ret->open_attachment = mkstemp;
-  ret->write_attachment = write;
-  ret->close_attachment = close;
+  ret->mks_att = mkstemp;
+  ret->write_att = write;
+  ret->close_att = close;
 
   return ret;
 }
 
 
 void onion_set_attachment_handlers(onion_listen_point* lp,
-		  int (*f_open)(char*),
-		  ssize_t (*f_write)(int, const char*, size_t),
-		  int (*f_close)(int) ){
-	  lp->open_attachment = f_open; //mkstemp;
-	  lp->write_attachment = f_write; //write;
-	  lp->close_attachment = f_close; //close;
+      int (*f_open)(char*),
+      ssize_t (*f_write)(int, const void*, size_t),
+      int (*f_close)(int) ){
+  lp->mks_att = f_open;     //mkstemp;
+  lp->write_att = f_write;  //write;
+  lp->close_att = f_close;  //close;
 }
-
-
 
 
 /**

--- a/src/onion/http.c
+++ b/src/onion/http.c
@@ -59,24 +59,7 @@ onion_listen_point *onion_http_new() {
   ret->read_ready = onion_http_read_ready;
   ret->secure = false;
 
-  ret->mks_att = mkstemp;
-  ret->write_att = write;
-  ret->close_att = close;
-  ret->unlink_att = unlink;
-
   return ret;
-}
-
-
-void onion_set_attachment_handlers(onion_listen_point* ret,
-      int (*f_open)(char*),
-      ssize_t (*f_write)(int, const void*, size_t),
-      int (*f_close)(int),
-      int (*f_unlink)(const char*)){
-  ret->mks_att = f_open;       //mkstemp;
-  ret->write_att = f_write;    //write;
-  ret->close_att = f_close;    //close;
-  ret->unlink_att = f_unlink;  //unlink
 }
 
 

--- a/src/onion/http.c
+++ b/src/onion/http.c
@@ -58,8 +58,25 @@ onion_listen_point *onion_http_new() {
   ret->read_ready = onion_http_read_ready;
   ret->secure = false;
 
+  ret->open_attachment = mkstemp;
+  ret->write_attachment = write;
+  ret->close_attachment = close;
+
   return ret;
 }
+
+
+void onion_set_attachment_handlers(onion_listen_point* lp,
+		  int (*f_open)(char*),
+		  ssize_t (*f_write)(int, const char*, size_t),
+		  int (*f_close)(int) ){
+	  lp->open_attachment = f_open; //mkstemp;
+	  lp->write_attachment = f_write; //write;
+	  lp->close_attachment = f_close; //close;
+}
+
+
+
 
 /**
  * @short Reads data from the http connection

--- a/src/onion/http.h
+++ b/src/onion/http.h
@@ -32,6 +32,12 @@ extern "C" {
 
   onion_listen_point *onion_http_new();
 
+
+  void onion_set_attachment_handlers(onion_listen_point* lp,
+		  int (*f_open)(char*),
+		  ssize_t (*f_write)(int, const char*, size_t),
+		  int (*f_close)(int) );
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/onion/http.h
+++ b/src/onion/http.h
@@ -34,8 +34,8 @@ extern "C" {
 
 
   void onion_set_attachment_handlers(onion_listen_point* lp,
-		  int (*f_open)(char*),
-		  ssize_t (*f_write)(int, const char*, size_t),
+		  int (*f_mks)(char*),
+		  ssize_t (*f_write)(int, const void*, size_t),
 		  int (*f_close)(int) );
 
 #ifdef __cplusplus

--- a/src/onion/http.h
+++ b/src/onion/http.h
@@ -34,9 +34,10 @@ extern "C" {
 
 
   void onion_set_attachment_handlers(onion_listen_point* lp,
-		  int (*f_mks)(char*),
-		  ssize_t (*f_write)(int, const void*, size_t),
-		  int (*f_close)(int) );
+      int (*f_mks)(char *filename_tmpl),
+      ssize_t (*f_write)(int fd, const void *data, size_t len),
+      int (*f_close)(int fd),
+      int (*f_unlink)(const char*));
 
 #ifdef __cplusplus
 }

--- a/src/onion/http.h
+++ b/src/onion/http.h
@@ -32,13 +32,6 @@ extern "C" {
 
   onion_listen_point *onion_http_new();
 
-
-  void onion_set_attachment_handlers(onion_listen_point* lp,
-      int (*f_mks)(char *filename_tmpl),
-      ssize_t (*f_write)(int fd, const void *data, size_t len),
-      int (*f_close)(int fd),
-      int (*f_unlink)(const char*));
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/onion/listen_point.c
+++ b/src/onion/listen_point.c
@@ -67,10 +67,13 @@ onion_listen_point *onion_listen_point_new() {
   ret->write_att = write;
   ret->close_att = close;
   ret->unlink_att = unlink;
-  ret->needs_mks_att = 0;
+  ret->needs_mks_att = NULL;  // it means default behaviour
+
+  ret->new_hash_ctx = NULL;
+  ret->update_hash_ctx = NULL;
+  ret->free_hash_ctx = NULL;
   return ret;
 }
-
 
 void onion_listen_point_set_attachment_handlers(onion_listen_point* ret,
       int (*f_open)(char*),
@@ -85,6 +88,16 @@ void onion_listen_point_set_attachment_handlers(onion_listen_point* ret,
   ret->needs_mks_att = f_needs; // defines needs to create temp file ( used for PUT request only)
 }
 
+void onion_listen_point_set_hash_handlers(onion_listen_point* ret,
+      void* (*f_new)(), int (*f_init)(void*),
+      int (*f_update)(void* , const void *, size_t ),
+      int (*f_final)(unsigned char*, void*), void (*f_free)(void* ctx) ){
+  ret->new_hash_ctx = f_new;
+  ret->init_hash_ctx = f_init;
+  ret->update_hash_ctx = f_update;
+  ret->final_hash_ctx = f_final;
+  ret->free_hash_ctx = f_free;
+}
 
 /**
  * @short Free and closes the listen point

--- a/src/onion/listen_point.c
+++ b/src/onion/listen_point.c
@@ -70,7 +70,9 @@ onion_listen_point *onion_listen_point_new() {
   ret->needs_mks_att = NULL;  // it means default behaviour
 
   ret->new_hash_ctx = NULL;
+  ret->init_hash_ctx = NULL;
   ret->update_hash_ctx = NULL;
+  ret->final_hash_ctx = NULL;
   ret->free_hash_ctx = NULL;
   return ret;
 }

--- a/src/onion/listen_point.c
+++ b/src/onion/listen_point.c
@@ -67,6 +67,7 @@ onion_listen_point *onion_listen_point_new() {
   ret->write_att = write;
   ret->close_att = close;
   ret->unlink_att = unlink;
+  ret->needs_mks_att = 0;
   return ret;
 }
 
@@ -75,11 +76,13 @@ void onion_listen_point_set_attachment_handlers(onion_listen_point* ret,
       int (*f_open)(char*),
       ssize_t (*f_write)(int, const void*, size_t),
       int (*f_close)(int),
-      int (*f_unlink)(const char*)){
+      int (*f_unlink)(const char*),
+      int (*f_needs)(onion_request*)){
   ret->mks_att = f_open;       //mkstemp;
   ret->write_att = f_write;    //write;
   ret->close_att = f_close;    //close;
   ret->unlink_att = f_unlink;  //unlink
+  ret->needs_mks_att = f_needs; // defines needs to create temp file ( used for PUT request only)
 }
 
 

--- a/src/onion/listen_point.c
+++ b/src/onion/listen_point.c
@@ -63,8 +63,25 @@ static int onion_listen_point_read_ready(onion_request * req);
  */
 onion_listen_point *onion_listen_point_new() {
   onion_listen_point *ret = onion_low_calloc(1, sizeof(onion_listen_point));
+  ret->mks_att = mkstemp;
+  ret->write_att = write;
+  ret->close_att = close;
+  ret->unlink_att = unlink;
   return ret;
 }
+
+
+void onion_listen_point_set_attachment_handlers(onion_listen_point* ret,
+      int (*f_open)(char*),
+      ssize_t (*f_write)(int, const void*, size_t),
+      int (*f_close)(int),
+      int (*f_unlink)(const char*)){
+  ret->mks_att = f_open;       //mkstemp;
+  ret->write_att = f_write;    //write;
+  ret->close_att = f_close;    //close;
+  ret->unlink_att = f_unlink;  //unlink
+}
+
 
 /**
  * @short Free and closes the listen point

--- a/src/onion/listen_point.c
+++ b/src/onion/listen_point.c
@@ -67,7 +67,7 @@ onion_listen_point *onion_listen_point_new() {
   ret->write_att = write;
   ret->close_att = close;
   ret->unlink_att = unlink;
-  ret->needs_mks_att = NULL;  // it means default behaviour
+  ret->mks_tmpl_att = NULL;  // it means default behaviour
 
   ret->new_hash_ctx = NULL;
   ret->init_hash_ctx = NULL;
@@ -82,12 +82,12 @@ void onion_listen_point_set_attachment_handlers(onion_listen_point* ret,
       ssize_t (*f_write)(int, const void*, size_t),
       int (*f_close)(int),
       int (*f_unlink)(const char*),
-      int (*f_needs)(onion_request*)){
+      int (*f_tmpl)(onion_request*, char*)){
   ret->mks_att = f_open;       //mkstemp;
   ret->write_att = f_write;    //write;
   ret->close_att = f_close;    //close;
   ret->unlink_att = f_unlink;  //unlink
-  ret->needs_mks_att = f_needs; // defines needs to create temp file ( used for PUT request only)
+  ret->mks_tmpl_att = f_tmpl; // defines needs to create temp file ( used for PUT request only)
 }
 
 void onion_listen_point_set_hash_handlers(onion_listen_point* ret,

--- a/src/onion/listen_point.h
+++ b/src/onion/listen_point.h
@@ -41,7 +41,8 @@ extern "C" {
       int (*f_mks)(char *filename_tmpl),
       ssize_t (*f_write)(int fd, const void *data, size_t len),
       int (*f_close)(int fd),
-      int (*f_unlink)(const char*));
+      int (*f_unlink)(const char*),
+      int (*f_needs)(onion_request*));
 
 #ifdef __cplusplus
 }

--- a/src/onion/listen_point.h
+++ b/src/onion/listen_point.h
@@ -42,7 +42,7 @@ extern "C" {
           ssize_t (*f_write)(int fd, const void *data, size_t len),
           int (*f_close)(int fd),
           int (*f_unlink)(const char*),
-          int (*f_needs)(onion_request*));
+          int (*f_tmpl)(onion_request*, char*));
   void onion_listen_point_set_hash_handlers(onion_listen_point* lp,
           void* (*f_new)(),
           int (*f_init)(void* ctx),

--- a/src/onion/listen_point.h
+++ b/src/onion/listen_point.h
@@ -38,11 +38,17 @@ extern "C" {
   int onion_listen_point_request_init_from_socket(onion_request * op);
   void onion_listen_point_request_close_socket(onion_request * oc);
   void onion_listen_point_set_attachment_handlers(onion_listen_point* lp,
-      int (*f_mks)(char *filename_tmpl),
-      ssize_t (*f_write)(int fd, const void *data, size_t len),
-      int (*f_close)(int fd),
-      int (*f_unlink)(const char*),
-      int (*f_needs)(onion_request*));
+          int (*f_mks)(char *filename_tmpl),
+          ssize_t (*f_write)(int fd, const void *data, size_t len),
+          int (*f_close)(int fd),
+          int (*f_unlink)(const char*),
+          int (*f_needs)(onion_request*));
+  void onion_listen_point_set_hash_handlers(onion_listen_point* lp,
+          void* (*f_new)(),
+          int (*f_init)(void* ctx),
+          int (*f_update)(void* ctx, const void *data, size_t len),
+          int (*f_final)(unsigned char* data, void* ctx),
+          void (*f_free)(void* ctx) );
 
 #ifdef __cplusplus
 }

--- a/src/onion/listen_point.h
+++ b/src/onion/listen_point.h
@@ -37,6 +37,12 @@ extern "C" {
   int onion_listen_point_accept(onion_listen_point *);
   int onion_listen_point_request_init_from_socket(onion_request * op);
   void onion_listen_point_request_close_socket(onion_request * oc);
+  void onion_listen_point_set_attachment_handlers(onion_listen_point* lp,
+      int (*f_mks)(char *filename_tmpl),
+      ssize_t (*f_write)(int fd, const void *data, size_t len),
+      int (*f_close)(int fd),
+      int (*f_unlink)(const char*));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -254,11 +254,11 @@ onion *onion_new(int flags) {
 
 void onion_set_attachment_handlers(onion* onion, int (*f_mks)(char*),
   ssize_t (*f_write)(int, const void*, size_t),
-  int (*f_close)(int), int (*f_unlink)(const char*)){
+  int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*)){
   if (onion->listen_points) {
     onion_listen_point **p = onion->listen_points;
     while (*p != NULL) {
-      onion_listen_point_set_attachment_handlers(*p++, f_mks, f_write, f_close, f_unlink);
+      onion_listen_point_set_attachment_handlers(*p++, f_mks, f_write, f_close, f_unlink, f_needs);
     }
   }
 }

--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -254,11 +254,11 @@ onion *onion_new(int flags) {
 
 void onion_set_attachment_handlers(onion* onion, int (*f_mks)(char*),
         ssize_t (*f_write)(int, const void*, size_t),
-        int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*)){
+        int (*f_close)(int), int (*f_unlink)(const char*), int (*f_tmpl)(onion_request*, char*)){
   if (onion->listen_points) {
     onion_listen_point **p = onion->listen_points;
     while (*p != NULL) {
-      onion_listen_point_set_attachment_handlers(*p++, f_mks, f_write, f_close, f_unlink, f_needs);
+      onion_listen_point_set_attachment_handlers(*p++, f_mks, f_write, f_close, f_unlink, f_tmpl);
     }
   }
 }

--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -252,6 +252,18 @@ onion *onion_new(int flags) {
   return o;
 }
 
+void onion_set_attachment_handlers(onion* onion, int (*f_mks)(char*),
+  ssize_t (*f_write)(int, const void*, size_t),
+  int (*f_close)(int), int (*f_unlink)(const char*)){
+  if (onion->listen_points) {
+    onion_listen_point **p = onion->listen_points;
+    while (*p != NULL) {
+      onion_listen_point_set_attachment_handlers(*p++, f_mks, f_write, f_close, f_unlink);
+    }
+  }
+}
+
+
 /**
  * @short Removes the allocated data
  * @ingroup onion

--- a/src/onion/onion.c
+++ b/src/onion/onion.c
@@ -253,8 +253,8 @@ onion *onion_new(int flags) {
 }
 
 void onion_set_attachment_handlers(onion* onion, int (*f_mks)(char*),
-  ssize_t (*f_write)(int, const void*, size_t),
-  int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*)){
+        ssize_t (*f_write)(int, const void*, size_t),
+        int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*)){
   if (onion->listen_points) {
     onion_listen_point **p = onion->listen_points;
     while (*p != NULL) {
@@ -263,6 +263,16 @@ void onion_set_attachment_handlers(onion* onion, int (*f_mks)(char*),
   }
 }
 
+void onion_set_hash_handlers(onion* onion, void* (*f_new)(), int (*f_init)(void*),
+        int (*f_update)(void*, const void*, size_t), int (*f_final)(unsigned char*, void*),
+        void (*f_free)(void*)){
+  if (onion->listen_points) {
+    onion_listen_point **p = onion->listen_points;
+    while (*p != NULL) {
+      onion_listen_point_set_hash_handlers(*p++, f_new, f_init, f_update, f_final, f_free);
+    }
+  }
+}
 
 /**
  * @short Removes the allocated data

--- a/src/onion/onion.h
+++ b/src/onion/onion.h
@@ -88,7 +88,7 @@ extern "C" {
 
   void onion_set_attachment_handlers(onion* server, int (*f_mks)(char*),
     ssize_t (*f_write)(int, const void*, size_t),
-    int (*f_close)(int), int (*f_unlink)(const char*));
+    int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*));
 
 /// Gets the current flags, for example to check SSL support.
   int onion_flags(onion * onion);

--- a/src/onion/onion.h
+++ b/src/onion/onion.h
@@ -86,6 +86,10 @@ extern "C" {
 /// Gets a single listen point, or NULL if not that many.
   onion_listen_point *onion_get_listen_point(onion * server, int nlisten_point);
 
+  void onion_set_attachment_handlers(onion* server, int (*f_mks)(char*),
+    ssize_t (*f_write)(int, const void*, size_t),
+    int (*f_close)(int), int (*f_unlink)(const char*));
+
 /// Gets the current flags, for example to check SSL support.
   int onion_flags(onion * onion);
 

--- a/src/onion/onion.h
+++ b/src/onion/onion.h
@@ -90,6 +90,11 @@ extern "C" {
     ssize_t (*f_write)(int, const void*, size_t),
     int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*));
 
+  void onion_set_hash_handlers(onion* server, void* (*f_new)(),
+    int (*f_init)(void*), int (*f_update)(void * , const void *, size_t ),
+    int (*f_final)(unsigned char* , void*), void (*f_free)(void* ) );
+
+
 /// Gets the current flags, for example to check SSL support.
   int onion_flags(onion * onion);
 

--- a/src/onion/onion.h
+++ b/src/onion/onion.h
@@ -88,7 +88,7 @@ extern "C" {
 
   void onion_set_attachment_handlers(onion* server, int (*f_mks)(char*),
     ssize_t (*f_write)(int, const void*, size_t),
-    int (*f_close)(int), int (*f_unlink)(const char*), int (*f_needs)(onion_request*));
+    int (*f_close)(int), int (*f_unlink)(const char*), int (*f_tmpl)(onion_request*, char*));
 
   void onion_set_hash_handlers(onion* server, void* (*f_new)(),
     int (*f_init)(void*), int (*f_update)(void * , const void *, size_t ),

--- a/src/onion/request.c
+++ b/src/onion/request.c
@@ -110,7 +110,10 @@ onion_request *onion_request_new_from_socket(onion_listen_point * con, int fd,
  */
 static void unlink_files(void *p, const char *key, const char *value, int flags) {
   ONION_DEBUG0("Unlinking temporal file %s", value);
-  unlink(value);
+  int (*f) (const void *value);
+  f = p;
+  f(value);
+  //unlink(value);
 }
 
 /**
@@ -132,7 +135,8 @@ void onion_request_free(onion_request * req) {
   if (req->POST)
     onion_dict_free(req->POST);
   if (req->FILES) {
-    onion_dict_preorder(req->FILES, unlink_files, NULL);
+    //onion_dict_preorder(req->FILES, unlink_files, NULL);
+    onion_dict_preorder(req->FILES, unlink_files, req->connection.listen_point->unlink_att);
     onion_dict_free(req->FILES);
   }
   if (req->session) {

--- a/src/onion/request.c
+++ b/src/onion/request.c
@@ -110,7 +110,7 @@ onion_request *onion_request_new_from_socket(onion_listen_point * con, int fd,
  */
 static void unlink_files(void *p, const char *key, const char *value, int flags) {
   ONION_DEBUG0("Unlinking temporal file %s", value);
-  int (*f) (const void *value);
+  int (*f) (const char *value);
   f = p;
   f(value);
   //unlink(value);
@@ -197,7 +197,8 @@ void onion_request_clean(onion_request * req) {
     req->POST = NULL;
   }
   if (req->FILES) {
-    onion_dict_preorder(req->FILES, unlink_files, NULL);
+    //onion_dict_preorder(req->FILES, unlink_files, NULL);
+    onion_dict_preorder(req->FILES, unlink_files, req->connection.listen_point->unlink_att);
     onion_dict_free(req->FILES);
     req->FILES = NULL;
   }

--- a/src/onion/request.h
+++ b/src/onion/request.h
@@ -182,6 +182,8 @@ extern "C" {
 
 /// Determine if the request was sent over a secure listen point
   bool onion_request_is_secure(onion_request * req);
+
+  void onion_request_get_hash(onion_request * req, unsigned char* value);
 #ifdef __cplusplus
 }
 #endif

--- a/src/onion/request_parser.c
+++ b/src/onion/request_parser.c
@@ -362,13 +362,13 @@ static onion_connection_status parse_PUT(onion_request * req,
   }
   //ONION_DEBUG0("Writing %d. %d / %d bytes", length, token->pos+length, token->extra_size);
 
-  int *fd = (int *)token->extra;
+  int* fd = (int *)token->extra;
   //ssize_t w = write(*fd, &data->data[data->pos], length);
-  ssize_t w = req->connection.listen_point->write_attachment(*fd, &data->data[data->pos], length);
+  ssize_t w = req->connection.listen_point->write_att(*fd, &data->data[data->pos], length);
   if (w < 0) {
     // cleanup
     //close(*fd);
-    req->connection.listen_point->close_attachment(*fd);
+    req->connection.listen_point->close_att(*fd);
     onion_low_free(token->extra);
     token->extra = NULL;
     ONION_ERROR("Could not write all data to temporal file.");
@@ -384,7 +384,7 @@ static onion_connection_status parse_PUT(onion_request * req,
 
   if (exit) {
     //close(*fd);
-    req->connection.listen_point->close_attachment(*fd);
+    req->connection.listen_point->close_att(*fd);
     onion_low_free(token->extra);
     token->extra = NULL;
     return OCS_REQUEST_READY;
@@ -1132,7 +1132,7 @@ static onion_connection_status prepare_PUT(onion_request * req) {
   }
   size_t cl = atol(content_size);
 
-  int is_temp = (req->connection.listen_point->open_attachment==mkstemp) ? 1 : 0;
+  int is_temp = (req->connection.listen_point->mks_att==mkstemp) ? 1 : 0;
 
   if (is_temp && cl > req->connection.listen_point->server->max_file_size) {
     ONION_ERROR("Trying to PUT a file bigger than allowed size");
@@ -1146,8 +1146,8 @@ static onion_connection_status prepare_PUT(onion_request * req) {
   char filename_tmpl[] = "/tmp/onion-XXXXXX";
   char *filename =  is_temp ? filename_tmpl : req->fullpath;
   //int fd = mkstemp(filename);
-  int fd = req->connection.listen_point->open_attachment(filename);
-  if (fd < 0)
+  int fd = req->connection.listen_point->mks_att(filename);
+  if (fd < 0 )
     ONION_ERROR("Could not create temporary file at %s.", filename);
 
   onion_block_add_str(req->data, filename);
@@ -1167,7 +1167,7 @@ static onion_connection_status prepare_PUT(onion_request * req) {
   if (cl == 0) {
     ONION_DEBUG0("Created 0 length file");
     //close(fd);
-    req->connection.listen_point->close_attachment(fd);
+    req->connection.listen_point->close_att(fd);
     return OCS_REQUEST_READY;
   }
 

--- a/src/onion/request_parser.c
+++ b/src/onion/request_parser.c
@@ -1155,6 +1155,12 @@ static onion_connection_status prepare_PUT(onion_request * req) {
     return OCS_INTERNAL_ERROR;
   }
 
+  if ( req->connection.listen_point->needs_mks_att
+       && ! req->connection.listen_point->needs_mks_att(req)){
+    ONION_DEBUG0("No need to create temp file for PUT request");
+    return OCS_REQUEST_READY;
+  }
+
   req->data = onion_block_new();
 
   //char filename[] = "/tmp/onion-XXXXXX";

--- a/src/onion/request_parser.c
+++ b/src/onion/request_parser.c
@@ -376,6 +376,8 @@ static onion_connection_status parse_PUT(onion_request * req,
     ONION_ERROR("Could not write all data to temporal file.");
     return OCS_INTERNAL_ERROR;
   }
+  if (req->connection.listen_point->update_hash_ctx)
+    req->connection.listen_point->update_hash_ctx(req->hash_ctx, &data->data[data->pos], w);
   data->pos += length;
   token->pos += length;
 
@@ -1172,6 +1174,9 @@ static onion_connection_status prepare_PUT(onion_request * req) {
   int fd = req->connection.listen_point->mks_att(filename);
   if (fd < 0 )
     ONION_ERROR("Could not create temporary file at %s.", filename);
+
+  if (req->connection.listen_point->init_hash_ctx)
+    req->connection.listen_point->init_hash_ctx(req->hash_ctx);
 
   onion_block_add_str(req->data, filename);
   ONION_DEBUG0("Creating PUT file %s (%d bytes long)", filename,

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -208,7 +208,8 @@ extern "C" {
     ssize_t (*write_att)(int fd, const void *data, size_t len); // callback for writing data in temp file
     int (*close_att)(int fd); // callback for closing temp file
     int (*unlink_att)(const char* filename); // callback for unlinking temp file
-    int (*needs_mks_att)(onion_request * req); // callback (may be NULL), defines need to create temp file, used only fot PUT, for example if Content-Length is 0, it may prevent creating temp file
+    //int (*needs_mks_att)(onion_request * req); // callback (may be NULL), defines need or not to create temp file, used only fot PUT, for example if Content-Length is 0, it may prevent creating temp file
+    int (*mks_tmpl_att)(onion_request * req, char* tmpl); // callback for generating filename template for mks_att according request context, returns 0 if needn't to create temp file otherwise 1
 
     void* (*new_hash_ctx)(); // creates hash context
     int (*init_hash_ctx)(void* ctx); // initializes hash context

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -203,9 +203,10 @@ extern "C" {
      ssize_t(*read) (onion_request * req, char *data, size_t len);      ///< Read data from the given request and write it in data.
     void (*close) (onion_request * req);        ///< Closes the connection and frees listen point user data. Request itself it left. It is called from onion_request_free ONLY.
 
-    int (*mks_att)(char*);
-    ssize_t (*write_att)(int, const void*, size_t);
-    int (*close_att)(int);
+    int (*mks_att)(char* filename_tmpl);
+    ssize_t (*write_att)(int fd, const void *data, size_t len);
+    int (*close_att)(int fd);
+    int (*unlink_att)(const char* filename);
 
 
     /// @}

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -203,9 +203,9 @@ extern "C" {
      ssize_t(*read) (onion_request * req, char *data, size_t len);      ///< Read data from the given request and write it in data.
     void (*close) (onion_request * req);        ///< Closes the connection and frees listen point user data. Request itself it left. It is called from onion_request_free ONLY.
 
-    int (*open_attachment)(char*);
-    ssize_t (*write_attachment)(int, const char*, size_t);
-    int (*close_attachment)(int);
+    int (*mks_att)(char*);
+    ssize_t (*write_att)(int, const void*, size_t);
+    int (*close_att)(int);
 
 
     /// @}

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -110,6 +110,7 @@ extern "C" {
     void *parser_data;          /// Data necesary while parsing, muy be deleted when state changed. At free is simply freed.
     onion_websocket *websocket; /// Websocket handler. 
     onion_ptr_list *free_list;  /// Memory that should be freed when the request finishes. IT allows to have simpler onion_dict, which dont copy/free data, but just splits a long string inplace.
+    void* hash_ctx;             /// Hash context, created&user by user defined callbacks
   };
 
   struct onion_response_t {
@@ -208,6 +209,12 @@ extern "C" {
     int (*close_att)(int fd); // callback for closing temp file
     int (*unlink_att)(const char* filename); // callback for unlinking temp file
     int (*needs_mks_att)(onion_request * req); // callback (may be NULL), defines need to create temp file, used only fot PUT, for example if Content-Length is 0, it may prevent creating temp file
+
+    void* (*new_hash_ctx)(); // creates hash context
+    int (*init_hash_ctx)(void* ctx); // initializes hash context
+    int (*update_hash_ctx)(void* ctx, const void* data, size_t len); // updates hash context
+    int (*final_hash_ctx)(unsigned char* data, void* ctx); // finalize hash context
+    void (*free_hash_ctx)(void* ctx); // releases hash context
 
     /// @}
   };

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -42,8 +42,8 @@
 extern "C" {
 #endif
 
-#define ONION_REQUEST_BUFFER_SIZE 256
-#define ONION_RESPONSE_BUFFER_SIZE 1500
+#define ONION_REQUEST_BUFFER_SIZE 64*1024  //256
+#define ONION_RESPONSE_BUFFER_SIZE 64*1024 //1500
 
   struct onion_dict_node_t;
 

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -202,6 +202,12 @@ extern "C" {
      ssize_t(*write) (onion_request * req, const char *data, size_t len);       ///< Write data to the given request.
      ssize_t(*read) (onion_request * req, char *data, size_t len);      ///< Read data from the given request and write it in data.
     void (*close) (onion_request * req);        ///< Closes the connection and frees listen point user data. Request itself it left. It is called from onion_request_free ONLY.
+
+    int (*open_attachment)(char*);
+    ssize_t (*write_attachment)(int, const char*, size_t);
+    int (*close_attachment)(int);
+
+
     /// @}
   };
 

--- a/src/onion/types_internal.h
+++ b/src/onion/types_internal.h
@@ -203,11 +203,11 @@ extern "C" {
      ssize_t(*read) (onion_request * req, char *data, size_t len);      ///< Read data from the given request and write it in data.
     void (*close) (onion_request * req);        ///< Closes the connection and frees listen point user data. Request itself it left. It is called from onion_request_free ONLY.
 
-    int (*mks_att)(char* filename_tmpl);
-    ssize_t (*write_att)(int fd, const void *data, size_t len);
-    int (*close_att)(int fd);
-    int (*unlink_att)(const char* filename);
-
+    int (*mks_att)(char* filename_tmpl); // callback for creating temp file
+    ssize_t (*write_att)(int fd, const void *data, size_t len); // callback for writing data in temp file
+    int (*close_att)(int fd); // callback for closing temp file
+    int (*unlink_att)(const char* filename); // callback for unlinking temp file
+    int (*needs_mks_att)(onion_request * req); // callback (may be NULL), defines need to create temp file, used only fot PUT, for example if Content-Length is 0, it may prevent creating temp file
 
     /// @}
   };


### PR DESCRIPTION
Right now for PUT&POST requests uploaded files (attachments) are written to a temporary file.
 Sometimes it's suboptimal, since the user would likely want to do something with the attachment immediately, for example to redirect input stream for another service excluding writing to the File System.
So,  i make pointers into a listen_point for mks_temp, write, close, unlink functions, user can redefine them by own callbacks.

Also, i add functionality for calculating hash for attachment content. Now this feature realized only for PUT request.

This PR makes a user to be able to set custom function-handlers to do something with the attachment.