### PR TITLE
Fix double free in examples/ofileserver

### DIFF
--- a/examples/ofileserver/fileserver.c
+++ b/examples/ofileserver/fileserver.c
@@ -130,8 +130,6 @@ int main(int argc, char **argv) {
     perror("Cant create the server");
   }
 
-  onion_free(o);
-
   return 0;
 }
 


### PR DESCRIPTION
Running examples/ofileserver with valgrind revealed double free, which is caused by calling free_onion (custom function that calls onion_free) on SIGINT and then calling onion_free. So this pull request just removes that second onion_free.