### PR TITLE
Fix ninja build by not relying on shell expansion

### DIFF
--- a/examples/oterm/CMakeLists.txt
+++ b/examples/oterm/CMakeLists.txt
@@ -3,11 +3,13 @@
 include_directories (${PROJECT_SOURCE_DIR}/src/) 
 include_directories (${CMAKE_CURRENT_BINARY_DIR}) 
 
+file(GLOB FILES_LIST_IN_DIR_STATIC "${CMAKE_CURRENT_SOURCE_DIR}/static/*")
+
 add_custom_command(
    OUTPUT oterm_data.c
    COMMAND ${OPACK} ${CMAKE_CURRENT_SOURCE_DIR}/static
               -o ${CMAKE_CURRENT_BINARY_DIR}/oterm_data.c
-   DEPENDS ${OPACK} ${CMAKE_CURRENT_SOURCE_DIR}/static/*
+   DEPENDS ${OPACK} ${FILES_LIST_IN_DIR_STATIC}
    )
 
 if(EXISTS /usr/share/javascript/jquery/jquery.min.js)


### PR DESCRIPTION
Building the project with `ninja` backend resulted in

    ninja: error: '../examples/oterm/static/*', needed by 'examples/oterm/oterm_data.c', missing and no known rule to make it

Fix this by using CMake built-in functional to list all files