### PR TITLE
Static date header

### DIFF
--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -49,7 +49,7 @@ const char *onion_response_code_description(int code);
 
 #ifndef DONT_USE_DATE_HEADER
 static volatile time_t onion_response_last_time = 0;
-static char onion_response_last_date_header[200] = { 0 };
+static char onion_response_last_date_header[128] = { 0 };
 #ifdef HAVE_PTHREADS
 pthread_rwlock_t onion_response_date_lock = PTHREAD_RWLOCK_INITIALIZER;
 #endif


### PR DESCRIPTION
This is a proposal to fix #254 . 
It just converts the storage for the date header into a fixed array. So, valgrind does not complain about the non-freed array at program end.
The change doesn't release us from using the locking around reading/writing the date_header.