### PR TITLE
docs: fix simple typo, reomves -> removes

### DIFF
--- a/src/onion/handlers/auth_pam.c
+++ b/src/onion/handlers/auth_pam.c
@@ -110,7 +110,7 @@ void onion_handler_auth_pam_delete(onion_handler_auth_pam_data * d) {
 }
 
 /**
- * @short Creates an path handler. If the path matches the regex, it reomves that from the regexp and goes to the inside_level.
+ * @short Creates an path handler. If the path matches the regex, it removes that from the regexp and goes to the inside_level.
  *
  * If on the inside level nobody answers, it just returns NULL, so ->next can answer.
  */

--- a/src/onion/handlers/path.c
+++ b/src/onion/handlers/path.c
@@ -65,7 +65,7 @@ void onion_handler_path_delete(void *data) {
 }
 
 /**
- * @short Creates an path handler. If the path matches the regex, it reomves that from the regexp and goes to the inside_level.
+ * @short Creates an path handler. If the path matches the regex, it removes that from the regexp and goes to the inside_level.
  *
  * If on the inside level nobody answers, it just returns NULL, so ->next can answer.
  */

--- a/src/onion/handlers/path.h
+++ b/src/onion/handlers/path.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-/// Creates an path handler. If the path matches the regex, it reomves that from the regexp and goes to the inside_level.
+/// Creates an path handler. If the path matches the regex, it removes that from the regexp and goes to the inside_level.
   onion_handler *onion_handler_path(const char *path,
                                     onion_handler * inside_level);
 


### PR DESCRIPTION
There is a small typo in src/onion/handlers/auth_pam.c, src/onion/handlers/path.c, src/onion/handlers/path.h.

Should read `removes` rather than `reomves`.

