### PR TITLE
Adding support of SameSite cookies (based on the master branch)

### DIFF
--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -637,6 +637,20 @@ bool onion_response_add_cookie(onion_response * res, const char *cookiename,
   if (flags & OC_SECURE)
     pos += snprintf(data + pos, sizeof(data) - pos, "; Secure");
 
+  switch (flags & (OC_SAMESITE_NONE | OC_SAMESITE_LAX | OC_SAMESITE_STRICT)) {
+  case OC_SAMESITE_NONE:
+    pos+=snprintf(data+pos, sizeof(data)-pos, "; SameSite=None");
+    break;
+  case OC_SAMESITE_LAX:
+    pos+=snprintf(data+pos, sizeof(data)-pos, "; SameSite=Lax");
+    break;
+  case OC_SAMESITE_STRICT:
+    pos+=snprintf(data+pos, sizeof(data)-pos, "; SameSite=Strict");
+    break;
+  default:
+    break;
+  }
+
   if (pos >= sizeof(data)) {
     ONION_WARNING("Cookie too long to be constructed. Not added to response.");
     return false;

--- a/src/onion/response.h
+++ b/src/onion/response.h
@@ -94,6 +94,9 @@ extern "C" {
   enum onion_response_cookie_flags_e {
     OC_HTTP_ONLY = 1,           ///< This cookie is not shown via javascript
     OC_SECURE = 2,              ///< This cookie is sent only via https (info for the client, not the server).
+    OC_SAMESITE_NONE=0x10,      ///< This cookie will be sent in all contexts, i.e. in responses to both first-party and cross-origin requests. When using this flag, OC_SECURE *MUST* also be used (or the cookie will be blocked by clients).
+    OC_SAMESITE_LAX=0x11,       ///< This cookie won't be sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link). This is the default option to recent browser versions if none of these OC_SAMESITE_* flags are used.
+    OC_SAMESITE_STRICT=0x12,    ///< This cookie will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
   };
   typedef enum onion_response_flags_e onion_response_flags;
 

--- a/src/onion/response.h
+++ b/src/onion/response.h
@@ -95,8 +95,8 @@ extern "C" {
     OC_HTTP_ONLY = 1,           ///< This cookie is not shown via javascript
     OC_SECURE = 2,              ///< This cookie is sent only via https (info for the client, not the server).
     OC_SAMESITE_NONE=0x10,      ///< This cookie will be sent in all contexts, i.e. in responses to both first-party and cross-origin requests. When using this flag, OC_SECURE *MUST* also be used (or the cookie will be blocked by clients).
-    OC_SAMESITE_LAX=0x11,       ///< This cookie won't be sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link). This is the default option to recent browser versions if none of these OC_SAMESITE_* flags are used.
-    OC_SAMESITE_STRICT=0x12,    ///< This cookie will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
+    OC_SAMESITE_LAX=0x20,       ///< This cookie won't be sent on normal cross-site subrequests (for example to load images or frames into a third party site), but are sent when a user is navigating to the origin site (i.e. when following a link). This is the default option to recent browser versions if none of these OC_SAMESITE_* flags are used.
+    OC_SAMESITE_STRICT=0x40,    ///< This cookie will only be sent in a first-party context and not be sent along with requests initiated by third party websites.
   };
   typedef enum onion_response_flags_e onion_response_flags;
 

--- a/tests/01-internal/03-response.c
+++ b/tests/01-internal/03-response.c
@@ -172,31 +172,44 @@ void t04_cookies() {
   FAIL_IF_NOT_EQUAL(ok, true);
 
   onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key5", "value5", -1, "/", "*.example.org", OC_HTTP_ONLY|OC_SECURE|OC_SAMESITE_STRICT);
+  ok = onion_response_add_cookie(res, "key5", "value5", -1, "/", "*.example.org", OC_HTTP_ONLY|OC_SECURE|OC_SAMESITE_STRICT);
   FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key5=value5; path=/; domain=*.example.org; HttpOnly; Secure; SameSite=Strict");
+  FAIL_IF_NOT_EQUAL(ok, true);
 
   onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX);
+  ok = onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX);
   FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
-  onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_NONE);
-  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
-  onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_NONE | OC_SAMESITE_LAX);
-  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
-  onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX | OC_SAMESITE_NONE);
-  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  FAIL_IF_NOT_EQUAL(ok, true);
 
   onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_STRICT);
+  ok = onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_NONE);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  FAIL_IF_NOT_EQUAL(ok, true);
+
+  onion_dict_remove(h, "Set-Cookie");
+  ok = onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_NONE | OC_SAMESITE_LAX);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  FAIL_IF_NOT_EQUAL(ok, true);
+
+  onion_dict_remove(h, "Set-Cookie");
+  ok = onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX | OC_SAMESITE_NONE);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  FAIL_IF_NOT_EQUAL(ok, true);
+
+  onion_dict_remove(h, "Set-Cookie");
+  ok = onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_STRICT);
   FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=Strict");
+  FAIL_IF_NOT_EQUAL(ok, true);
+
   onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_LAX);
+  ok = onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_LAX);
   FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=Lax");
+  FAIL_IF_NOT_EQUAL(ok, true);
+
   onion_dict_remove(h, "Set-Cookie");
-  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_NONE);
+  ok = onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_NONE);
   FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=None");
+  FAIL_IF_NOT_EQUAL(ok, true);
 
   int i;
   int valid_expires = 0;

--- a/tests/01-internal/03-response.c
+++ b/tests/01-internal/03-response.c
@@ -171,6 +171,33 @@ void t04_cookies() {
                     "key4=value4; domain=*.example.org; HttpOnly; path=/; Secure");
   FAIL_IF_NOT_EQUAL(ok, true);
 
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key5", "value5", -1, "/", "*.example.org", OC_HTTP_ONLY|OC_SECURE|OC_SAMESITE_STRICT);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key5=value5; path=/; domain=*.example.org; HttpOnly; Secure; SameSite=Strict");
+
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_NONE);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_NONE | OC_SAMESITE_LAX);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key6", "value6", -1, NULL, NULL, OC_SAMESITE_STRICT | OC_SAMESITE_LAX | OC_SAMESITE_NONE);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key6=value6");
+
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_STRICT);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=Strict");
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_LAX);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=Lax");
+  onion_dict_remove(h, "Set-Cookie");
+  onion_response_add_cookie(res, "key7", "value7", -1, NULL, NULL, OC_SAMESITE_NONE);
+  FAIL_IF_NOT_EQUAL_STR(onion_dict_get(h, "Set-Cookie"), "key7=value7; SameSite=None");
+
   int i;
   int valid_expires = 0;
   char tmpdate[100];


### PR DESCRIPTION
Linked issue #281 and patch to #282

Output of the test:

```
$ tests/01-internal/03-response                            
03-response.c:43 INFO Test t01_create_add_free
[DB7D2A00] [2021-01-08 12:53:58] [ERROR response.c:279] Bad formed response. Need a request at creation. Will not write headers.
03-response.c:57 INFO t01_create_add_free ends: 3 succeses / 0 failures

03-response.c:61 INFO Test t02_full_cycle_http10
[DB7D2A00] [2021-01-08 12:53:58] [INFO response.c:191] [(null)] "GET (null)" 200 30 (Close connection)
03-response.c:95 INFO t02_full_cycle_http10 ends: 8 succeses / 0 failures

03-response.c:99 INFO Test t03_full_cycle_http11
[DB7D2A00] [2021-01-08 12:53:58] [INFO response.c:191] [(null)] "GET /" 200 30 (Keep-Alive)
03-response.c:137 INFO t03_full_cycle_http11 ends: 8 succeses / 0 failures

03-response.c:141 INFO Test t04_cookies
03-response.c:229 ERROR FAIL IF NOT valid_expires
[DB7D2A00] [2021-01-08 12:53:58] [WARNING response.c:655] Cookie too long to be constructed. Not added to response.
[DB7D2A00] [2021-01-08 12:53:58] [ERROR response.c:279] Bad formed response. Need a request at creation. Will not write headers.
03-response.c:248 INFO t04_cookies ends: 27 succeses / 1 failures

03-response.c:252 INFO Test t05_printf
[DB7D2A00] [2021-01-08 12:53:58] [INFO response.c:191] [(null)] "GET (null)" 200 21 (Close connection)
03-response.c:275 INFO t05_printf ends: 1 succeses / 0 failures

03-response.c:279 INFO Test t06_empty
[DB7D2A00] [2021-01-08 12:53:58] [INFO response.c:191] [(null)] "GET (null)" 200 0 (Close connection)
03-response.c:306 INFO t06_empty ends: 2 succeses / 0 failures

03-response.c:310 INFO Test t07_large_printf
[DB7D2A00] [2021-01-08 12:53:58] [INFO response.c:191] [(null)] "GET (null)" 200 99999 (Close connection)
03-response.c:339 INFO t07_large_printf ends: 2 succeses / 0 failures

03-response.c:353 INFO TOTAL: 51 succeses / 1 failures
```