### PR TITLE
adding onion_request_get_method_name

### DIFF
--- a/src/onion/request.c
+++ b/src/onion/request.c
@@ -1,6 +1,6 @@
 /**
   Onion HTTP server library
-  Copyright (C) 2010-2018 David Moreno Montero and others
+  Copyright (C) 2010-2021 David Moreno Montero and others
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of, at your choice:
@@ -238,6 +238,17 @@ const char *onion_request_get_path(onion_request * req) {
 }
 
 /**
+ * @short Returns a pointer to some constant literal string containg the HTTP method name, or else NULL.
+ * @memberof onion_request_t
+ * @ingroup request
+ */
+const char *onion_request_get_method_name(onion_request * req) {
+  if (!req)
+    return NULL;
+  return onion_request_methods [req->flags & OR_METHODS];
+}
+
+/**
  * @short Returns a pointer to the string with the full path. Its a const and should not be trusted for long time.
  * @memberof onion_request_t
  * @ingroup request
@@ -245,6 +256,8 @@ const char *onion_request_get_path(onion_request * req) {
 const char *onion_request_get_fullpath(onion_request * req) {
   return req->fullpath;
 }
+
+
 
 /**
  * @short Gets the current flags, as in onion_request_flags_e

--- a/src/onion/request.h
+++ b/src/onion/request.h
@@ -123,6 +123,9 @@ extern "C" {
 /// Gets session data
   const char *onion_request_get_session(onion_request * req, const char *query);
 
+/// Get as literal constant string -e.g. "GET" or "PUT"- the method name or else NULL
+  const char *onion_request_get_method_name(onion_request * req);
+
 /// Gets the header header data dict
   const onion_dict *onion_request_get_header_dict(onion_request * req);
 


### PR DESCRIPTION
In some projects (including [bismon](https://github.com/bstarynk/bismon/) and perhaps later [RefPerSys](http://refpersys.org/)) it could be useful to get a literal string giving the method name (e.g. "GET" or "POST" etc...) for a given Onion web-request.

This patch declares and defines a new `onion_request_get_method_name` function. The API of LibOnion changes compatibly

If accepted, a future patch might be proposed to add a C++ binding to that function (for the [RefPerSys](http://refpersys.org/) project).

Regards from [Basile Starynkevitch](http://starynkevitch.net/Basile/) (near Paris, in France) - you may email me to <basile@starynkevitch.net>