### PR TITLE
adding C++ Onion::Request::Method_Name

### DIFF
--- a/src/bindings/cpp/request.hpp
+++ b/src/bindings/cpp/request.hpp
@@ -215,7 +215,7 @@ namespace Onion {
      * @short Gives a constant literal C string, such as "GET" or
      * "POST", describing the HTTP method.
      */
-    const char*Method_Name (void) const {
+    const char*methodName (void) const {
       return onion_request_get_method_name (ptr);
     };
   };

--- a/src/bindings/cpp/request.hpp
+++ b/src/bindings/cpp/request.hpp
@@ -1,6 +1,6 @@
 /**
   Onion HTTP server library
-  Copyright (C) 2010-2018 David Moreno Montero and others
+  Copyright (C) 2010-2021 David Moreno Montero and others
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of, at your choice:
@@ -211,6 +211,13 @@ namespace Onion {
 		 */ onion_request *c_handler() {
       return ptr;
     }
+    /**
+     * @short Gives a constant literal C string, such as "GET" or
+     * "POST", describing the HTTP method.
+     */
+    const char*Method_Name (void) const {
+      return onion_request_get_method_name (ptr);
+    };
   };
 }
 


### PR DESCRIPTION
This patch adds a C++ binding to `onion_request_get_method_name`. Such a patch could be useful to the [RefPerSys](http://refpersys.org/) project.

In my opinion, `ONION_VERSION_MINOR` should also be incremented to reflect this API improvement, but I don't know how to do that.

Regards from [Basile Starynkevitch](http://starynkevitch.net/Basile/) (near Paris, in France). Email me to [basile@starynkevitch.net](mailto:basile@starynkevitch.net) if needed.
