### PR TITLE
random-default.c: Don't exit if we read less bytes from /dev/random

### DIFF
--- a/src/onion/random-default.c
+++ b/src/onion/random-default.c
@@ -61,16 +61,18 @@ void onion_random_init() {
       srand(time(NULL));
     } else {
       unsigned int sr;
-      ssize_t n;
-      n = read(fd, &sr, sizeof(sr));
-      if (n != sizeof(sr)) {
-        ONION_ERROR
-            ("Error reading seed value from /dev/random after file descriptor opened");
-        exit(1);
-      } else {
-        close(fd);
-        srand(sr);
+      ssize_t n = 0;
+      while (n < sizeof(sr)) {
+        ssize_t r = read(fd, ((char *)&sr) + n, sizeof(sr) - n);
+        if (r < 0) {
+          ONION_ERROR
+              ("Error reading seed value from /dev/random after file descriptor opened");
+          exit(1);
+        }
+        n += r;
       }
+      close(fd);
+      srand(sr);
     }
   }
   onion_random_refcount++;


### PR DESCRIPTION
Hi! First time contributing here so please let me know if there's anything else needed for the PR.

Reading from /dev/random might return less than the expected amount of bytes, and that should be okay. We can just keep reading until we have enough bytes.

(imo it'd probably [be better to use /dev/urandom here](https://www.2uo.de/myths-about-urandom/ ) and we could even read from /dev/urandom on each call to `onion_random_generate`, but this change should avoid making the program exit without changing the random implementation too much)