### PR TITLE
06-onion.c: Fix value of 'sizeof' when allocating 'pthread_t' array with 'malloc'

### DIFF
--- a/tests/01-internal/06-onion.c
+++ b/tests/01-internal/06-onion.c
@@ -163,7 +163,7 @@ void do_request_set_threaded(float wait_s, float wait_c, int nrequests,
   params.n_requests = nrequests;
   params.close_at_n = close;
 
-  pthread_t *thread = malloc(sizeof(pthread_t *) * nthreads);
+  pthread_t *thread = malloc(sizeof(pthread_t) * nthreads);
   pthread_t listen_thread;
   int i;
   pthread_create(&listen_thread, NULL, (void *)do_listen, NULL);
@@ -397,7 +397,7 @@ void t06_timeouts() {
   sleep(1);
 
   int nthreads = 10;
-  pthread_t *thread = malloc(sizeof(pthread_t *) * nthreads);
+  pthread_t *thread = malloc(sizeof(pthread_t) * nthreads);
   int i;
   for (i = 0; i < nthreads; i++) {
     pthread_create(&thread[i], NULL, (void *)do_timeout_request, NULL);


### PR DESCRIPTION
Hello, I suspect that the project uses an improper `sizeof` value when calling `malloc` inside the tests file. We are creating an array of `pthread_t` so we should call `malloc` with `sizeof(pthread_t)`, but we use the size of the pointer instead. 

The execution might run fine because `pthread_t` and `pthread_t *` can have the same size (both are 8 bytes on my machine), but that is not necessarily true. 

I think that we should change it.