### PR TITLE
Change `const std::string` to `const std::string&`

### DIFF
--- a/src/bindings/cpp/response.hpp
+++ b/src/bindings/cpp/response.hpp
@@ -76,8 +76,8 @@ namespace Onion {
     }
 
                 /**
-		 * @short Sets the response lenght. 
-		 * 
+		 * @short Sets the response length.
+		 *
 		 * If not set onion has some heuristics to try to guess it, or use chunked encoding.
 		 */
     void setLength(size_t length) {
@@ -90,7 +90,7 @@ namespace Onion {
        *
        * @param cookiename Name for the cookie
        * @param cookievalue Value for the cookis
-       * @param validity_t Seconds this cookie is valid (added to current datetime). -1 to do not expire, 0 to expire inmediatly.
+       * @param validity_t Seconds this cookie is valid (added to current datetime). -1 to do not expire, 0 to expire immediately.
        * @param path Cookie valid only for this path
        * @param Domain Cookie valid only for this domain (www.example.com, or *.example.com).
        * @param flags Flags from onion_cookie_flags_t, for example OC_SECURE or OC_HTTP_ONLY
@@ -98,11 +98,11 @@ namespace Onion {
        *
        * If validity is 0, cookie is set to expire right now.
        */
-    void addCookie(const std::string cookiename,
-                   const std::string cookievalue,
+    void addCookie(const std::string& cookiename,
+                   const std::string& cookievalue,
                    time_t validity_t,
-                   const std::string path,
-                   const std::string domain, int flags) {
+                   const std::string& path,
+                   const std::string& domain, int flags) {
 
       const char *_path = ((path.empty())? NULL : path.c_str());
       const char *_domain = ((domain.empty())? NULL : domain.c_str());

--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -604,8 +604,8 @@ onion_dict *onion_response_get_headers(onion_response * res) {
  *
  * @param res Response object
  * @param cookiename Name for the cookie
- * @param cookievalue Value for the cookis
- * @param validity_t Seconds this cookie is valid (added to current datetime). -1 to do not expire, 0 to expire inmediatly.
+ * @param cookievalue Value for the cookies
+ * @param validity_t Seconds this cookie is valid (added to current datetime). -1 to do not expire, 0 to expire immediately.
  * @param path Cookie valid only for this path
  * @param Domain Cookie valid only for this domain (www.example.com, or *.example.com).
  * @param flags Flags from onion_cookie_flags_t, for example OC_SECURE or OC_HTTP_ONLY


### PR DESCRIPTION
Hi,
I ran Cppcheck for static code analysis on the project and noticed that we have these 4 parameters that are non-reference const objects even though we could use const reference types which might be more performant in the case of `std::string`. And looking at some other functions, it seems like `const std::string&` is preferred over `const std::string` in the rest of the project.