### PR TITLE
Fix the value of a sizeof modulus when computing a random uuid.

### DIFF
--- a/examples/oterm/oterm_handler.c
+++ b/examples/oterm/oterm_handler.c
@@ -260,7 +260,7 @@ process *oterm_new(oterm_data * data, oterm_session * session,
     if (fd < 0) {
       const char random_chars[] = "0123456789abcdef-";
       for (i = 0; i < sizeof(oterm->uuid) - 1; i++) {
-        oterm->uuid[i] = random_chars[rand() % sizeof(random_chars)];
+        oterm->uuid[i] = random_chars[rand() % (sizeof(random_chars) - 1)];
       }
     }
     oterm->uuid[sizeof(oterm->uuid) - 1] = 0;


### PR DESCRIPTION
We need to use `sizeof(random_chars) - 1` as a modulus for `random_chars` instead of `sizeof(random_chars)` because the first variant can also return `\0` in the middle of the generated c-string.

This resolves #301 .