### PR TITLE
Fix a potential log spamming and DOS attack

### DIFF
--- a/src/onion/response.c
+++ b/src/onion/response.c
@@ -431,31 +431,8 @@ int onion_response_flush(onion_response * res) {
     char tmp[16];
     snprintf(tmp, sizeof(tmp), "%X\r\n", (unsigned int)res->buffer_pos);
     if ((w = write(req, tmp, strlen(tmp))) <= 0) {
-      // Sorry for this monstrocity, gotta be cross-platform.
-      #if __STDC_VERSION__ >= 201112 && !defined(__STDC_NO_THREADS__)
-      static _Thread_local time_t last_write_error_time = 0;
-      static _Thread_local unsigned int write_errors_since = 0;
-      #elif defined(_WIN32) && ( \
-        defined(_MSC_VER) || \
-        defined(__ICL) || \
-        defined(__DMC__) || \
-        defined(__BORLANDC__))
-      static __declspec(thread) time_t last_write_error_time = 0;
-      static __declspec(thread) unsigned int write_errors_since = 0;
-      #else
-      static __thread time_t last_write_error_time = 0;
-      static __thread unsigned int write_errors_since = 0;
-      #endif
-
-      if (time(NULL) - last_write_error_time >= 1)
-      {
-        ONION_WARNING("Error writing chunk encoding length (%X) %s. Aborting write. (x%u)",
-          (unsigned int)res->buffer_pos, strerror(errno), write_errors_since + 1);
-        write_errors_since = 0;
-        time(&last_write_error_time);
-      }
-      else
-        ++write_errors_since;
+      ONION_CALL_MAX_ONCE_PER_T_COUNT(1, ONION_WARNING, "Error writing chunk encoding length (%X) %s. Aborting write. (x%u)",
+        (unsigned int)res->buffer_pos, strerror(errno));
       
       return OCS_CLOSE_CONNECTION;
     }


### PR DESCRIPTION
# What does this do and why is this needed?
I have discovered an attack that allows you to attack any non-trivial programs that use onion. At the very least it allows you to spam the logs with a few hundred thousand useless messages, and maybe even deny service to other clients. And the worst part about it? You only need Firefox (maybe Chrome can do it as well, I haven't tested that) and a functional <kbd>F5</kbd> key.

## To reproduce it:

1. Download, compile and run the source file below, it's a program that simulates a non-trivial onion app by writing 200000-something chars when requested at `<Your IP>:8080/teapot`.
2. Download [Mozilla's finest web browser](https://www.mozilla.org/ru/firefox/new/) if you don't have it already.
3. Open up Firefox and browse to `localhost:8080/teapot`.
4. Make sure the Firefox window is in focus and hold down the <kbd>F5</kbd> key for a few minutes.
5. That's it. Now the logs are full of pointless messages and for me the program stopped responding for ~30 seconds.

<details>
<summary>C source file</summary>

```
#include <stdlib.h>

#include "onion/src/onion/onion.h"
#include "onion/src/onion/response.h"

static onion_connection_status be_a_teapot (void * _, onion_request * req, onion_response * rsp)
{
  (void) _; (void) req;
  onion_response_set_code (rsp, 418);

  onion_response_printf (rsp, "%s", "<!DOCTYPE html><h1 style=\"display: inline;\">418.</h1><h2 style=\"display: inline;\">I'm a teapot.</h2><hr><p>The resulting entity body is<strong> NOT</strong> short and stout.<br>Tip me over and pour me out<strong> AND ENJOY THE USELESS INVISIBLE A's BELOW</strong>.</p><p style=\"display: none;\">");
  for (unsigned int i = 0; i < 200000; ++i)
    onion_response_printf (rsp, "%c", 'A');
  onion_response_printf (rsp, "%s", "</p>");

  return OCS_PROCESSED;
}

int main ()
{
  onion * webserver = onion_new (O_THREADED);
  onion_url * webserver_urls = onion_root_url (webserver);

  onion_url_add (webserver_urls, "teapot", be_a_teapot);

  onion_set_hostname (webserver, "0.0.0.0");

  onion_listen (webserver);
  onion_free (webserver);

  return EXIT_SUCCESS;
}
```
</details>

## So, how does it work?
It's quite simple: when Firefox refreshes, it'll reset all current connections with the server, if any, and then it'll reconnect. Thus, by holding down <kbd>F5</kbd> Firefox will connect to the server and reset that connection almost immediately and will continue doing that while the key is being held down. When the connection is reset, onion will complain about being unable to write the chunk encoding length in a warning, which is reasonable behavior most of the time - but not always. By connecting and resetting countless times we'll not only create a bunch of useless warnings in the log, but we'll also make all the threads very busy writing that log down to the stdout (or syslog). And, quite obviously, when a thread is writing a warning to the log it's not doing any serving, and when all threads are writing to the log the client will not get served at all.

## The fix
The fix is as simple as the problem: allow onion to log a chunk encoding write error only once a second, and at other times just count the errors and output the count if an error occurs after a second since the previous warning had been written.

### Logs of the sample program **before** the commit
<details>
<summary>Some onion logs</summary>

```
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A14E5640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9F4E1640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[9FCE2640] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
[A24E8740] [2022-08-30 02:46:51] [WARNING response.c:436] Error writing chunk encoding length (5DC) Broken pipe. Aborting write.
```
</details>

### Logs of the sample program **after** the commit
<details>
<summary>Some more onion logs</summary>

```
[76D4D640] [2022-08-30 02:37:25] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 200298 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:25] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 200298 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[7754E640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Connection reset by peer. Aborting write. (x1)
[79D54740] [2022-08-30 02:37:26] [ERROR response.c:470] Error writing 1500 bytes (Broken pipe). Maybe closed connection. Code -1. 
[79D54740] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[77D4F640] [2022-08-30 02:37:26] [ERROR response.c:470] Error writing 1500 bytes (Broken pipe). Maybe closed connection. Code -1. 
[77D4F640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[78550640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[78D51640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[79552640] [2022-08-30 02:37:26] [ERROR response.c:470] Error writing 1500 bytes (Broken pipe). Maybe closed connection. Code -1. 
[79552640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[77D4F640] [2022-08-30 02:37:26] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 120564000 (Keep-Alive)
[79D53640] [2022-08-30 02:37:26] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x1)
[77D4F640] [2022-08-30 02:37:26] [ERROR response.c:470] Error writing 1500 bytes (Broken pipe). Maybe closed connection. Code -1. 
[76D4D640] [2022-08-30 02:37:26] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 255475500 (Keep-Alive)
[7754E640] [2022-08-30 02:37:26] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 289203000 (Keep-Alive)
[7754E640] [2022-08-30 02:37:26] [ERROR response.c:470] Error writing 1500 bytes (Broken pipe). Maybe closed connection. Code -1. 
[79552640] [2022-08-30 02:37:26] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 221746500 (Keep-Alive)
[79D54740] [2022-08-30 02:37:26] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 120564000 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x290018)
[79552640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x228379)
[77D4F640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x110453)
[78D51640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x65054)
[79D53640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x49581)
[78550640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x81892)
[79D54740] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x81263)
[7754E640] [2022-08-30 02:37:27] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x230463)
[76D4D640] [2022-08-30 02:37:27] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79552640] [2022-08-30 02:37:27] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:27] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79552640] [2022-08-30 02:37:27] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79552640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x444114)
[78550640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x53793)
[76D4D640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x396747)
[78D51640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x59457)
[79D53640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x58540)
[79D54740] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x55083)
[77D4F640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x62441)
[7754E640] [2022-08-30 02:37:28] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x57029)
[79552640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79D53640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[78D51640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[78550640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[77D4F640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 291450000 (Keep-Alive)
[7754E640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 286953000 (Keep-Alive)
[79D54740] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79552640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[7754E640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 200298 (Keep-Alive)
[76D4D640] [2022-08-30 02:37:28] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[78550640] [2022-08-30 02:37:29] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x147911)
[79D53640] [2022-08-30 02:37:29] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x184922)
[78D51640] [2022-08-30 02:37:29] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x176673)
[77D4F640] [2022-08-30 02:37:29] [WARNING response.c:453] Error writing chunk encoding length (5DC) Broken pipe. Aborting write. (x208733)
[77D4F640] [2022-08-30 02:37:29] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[79D53640] [2022-08-30 02:37:29] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[78550640] [2022-08-30 02:37:29] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
[78D51640] [2022-08-30 02:37:29] [INFO response.c:196] [127.0.0.1] "GET /teapot" 418 298197000 (Keep-Alive)
```
</details>
